### PR TITLE
Extension to A Single-Cell Atlas of Chromatin Accessibility in the Human Genome 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "notebooks/tools/ldsc"]
+	path = notebooks/tools/ldsc
+	url = https://github.com/bulik/ldsc.git

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import marimo
 
 __generated_with = "0.9.14"
@@ -14,123 +15,151 @@ def __():
     import pandas as pd
     import numpy as np
     from pathlib import Path
-    import gzip
-    import hashlib
-    from datetime import datetime
-    return mo, urllib, os, re, subprocess, pd, np, Path, gzip, hashlib, datetime
+    import json
+    import glob
+    import concurrent.futures
+    import multiprocessing
+    return mo, urllib, os, re, subprocess, pd, np, Path, json, glob, concurrent, multiprocessing
 
 
 @app.cell
 def __(mo):
     mo.md("""
-This notebook reproduces the LDSC cell-type–specific heritability analysis  
-from *Epigenomic dissection of Alzheimer's disease pinpoints causal variants and reveals epigenome erosion*.
+    This notebook reproduces the LDSC cell-type-specific heritability analysis
+    from *A single-cell atlas of chromatin accessibility in the human genome* (Zhang et al. 2021).
 
-All analyses are performed using **GRCh38 / hg38** coordinates.
-""")
+    All analyses are performed using **GRCh38 / hg38** coordinates.
+
+    Set `GWAS_INPUT_FILE` below to point to your GWAS summary statistics file.
+    The pipeline will auto-detect column names and derive a stem from the filename.
+    """)
     return
 
 
 @app.cell
-def __(mo):
-    GWAS_INPUT_FILE = "data/gwas/6152_9.gwas.imputed_v3.both_sexes.tsv.bgz"
-    gwas_stem = mo.state(GWAS_INPUT_FILE)
-    return (GWAS_INPUT_FILE, gwas_stem)
+def __(mo, os):
+    GWAS_INPUT_FILE = mo.ui.text(
+        value="data/gwas/mdd_symptoms_2023-Clin-MDD1_depressed.txt.gz",
+        label="GWAS input file path",
+        full_width=True,
+    )
+    W_HM3_SNPLIST   = "/mnt/hdd_1/rediet/hypothesis-generation-demo/ldsc/data/w_hm3.snplist"
+    HM3_NO_MHC_LIST = "data/reference/hm3_no_MHC.list.txt"
+    CATLAS_DIR       = "humanenhancer_atac_data"
+    CATLAS_URL       = "http://catlas.org/humanenhancer/data/cCREs/"
+    BROAD_CELL_TYPES = ["Ast", "Ex", "In", "Microglia", "OPC", "Oligo", "PerEndo"]
+    BROAD_BASE_URL   = "https://personal.broadinstitute.org/bjames/AD_snATAC/major_celltype_matrices/"
+
+    mo.vstack([
+        mo.md("### Configuration"),
+        GWAS_INPUT_FILE,
+        mo.md(f"w_hm3.snplist: `{W_HM3_SNPLIST}`"),
+    ])
+    return (
+        GWAS_INPUT_FILE,
+        W_HM3_SNPLIST,
+        HM3_NO_MHC_LIST,
+        CATLAS_DIR,
+        CATLAS_URL,
+        BROAD_CELL_TYPES,
+        BROAD_BASE_URL,
+    )
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, os):
-    import re as _re
-
-    _basename = os.path.basename(GWAS_INPUT_FILE)
+def __(GWAS_INPUT_FILE, os, re):
+    _path = GWAS_INPUT_FILE.value
+    _basename = os.path.basename(_path)
     _no_ext = _basename
-    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv"]:
+    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv", ".bgz"]:
         if _no_ext.endswith(_ext):
             _no_ext = _no_ext[: -len(_ext)]
             break
-
-    GWAS_STEM = _re.sub(r"[^A-Za-z0-9_\-]", "_", _no_ext)
-
-    SSF_FILE       = f"data/ssf/{GWAS_STEM}.h.tsv.gz"
-    SSF_YAML       = f"{SSF_FILE}-meta.yaml"
+    GWAS_STEM      = re.sub(r"[^A-Za-z0-9_\-]", "_", _no_ext)
+    GWAS_FILE      = _path
+    PREMUNGE_FILE  = f"data/munging_input/{GWAS_STEM}_premunge.tsv.gz"
     SUMSTATS_FILE  = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
+    MUNGE_PREFIX   = f"data/ldsc_input/{GWAS_STEM}"
+    CTS_FILE       = f"data/{GWAS_STEM}_cell_types.cts"
     RESULTS_PREFIX = f"results/{GWAS_STEM}_CellTypeSpecific"
 
     print(f"GWAS stem      : {GWAS_STEM}")
-    print(f"SSF file       : {SSF_FILE}")
+    print(f"GWAS file      : {GWAS_FILE}")
+    print(f"Premunge file  : {PREMUNGE_FILE}")
     print(f"Sumstats file  : {SUMSTATS_FILE}")
     print(f"Results prefix : {RESULTS_PREFIX}")
-
-    return (GWAS_STEM, SSF_FILE, SSF_YAML, SUMSTATS_FILE, RESULTS_PREFIX)
+    return (
+        GWAS_STEM,
+        GWAS_FILE,
+        PREMUNGE_FILE,
+        SUMSTATS_FILE,
+        MUNGE_PREFIX,
+        CTS_FILE,
+        RESULTS_PREFIX,
+    )
 
 
 @app.cell
 def __(mo):
-    mo.md("## 0. Setup: Download and configure LDSC")
+    mo.md("## 0. Setup: download and configure LDSC")
     return
 
 
 @app.cell
-def __(Path, subprocess, os):
+def __(Path, subprocess, os, json):
     TOOLS_DIR = Path("tools")
-    LDSC_DIR = TOOLS_DIR / "ldsc"
+    LDSC_DIR  = TOOLS_DIR / "ldsc"
     TOOLS_DIR.mkdir(exist_ok=True)
 
-    env_check = subprocess.run(["conda", "env", "list"], capture_output=True, text=True)
-    ldsc_env_exists = "ldsc27" in env_check.stdout
-
-    if not ldsc_env_exists:
+    _env_check = subprocess.run(["conda", "env", "list"], capture_output=True, text=True)
+    if "ldsc27" not in _env_check.stdout:
         subprocess.run(["conda", "create", "-n", "ldsc27", "python=2.7", "-y"], check=True)
 
-    conda_prefix = subprocess.run(
-        ["conda", "env", "list", "--json"],
-        capture_output=True, text=True, check=True
+    _conda_json = subprocess.run(
+        ["conda", "env", "list", "--json"], capture_output=True, text=True, check=True
     )
-    import json
-    envs = json.loads(conda_prefix.stdout)["envs"]
-    ldsc27_path = [e for e in envs if "ldsc27" in e][0]
+    _envs = json.loads(_conda_json.stdout)["envs"]
+    ldsc27_path = [e for e in _envs if "ldsc27" in e][0]
 
-    bedtools_path = os.path.join(ldsc27_path, "bin", "bedtools")
-    if not os.path.exists(bedtools_path):
+    if not os.path.exists(os.path.join(ldsc27_path, "bin", "bedtools")):
         subprocess.run(
             ["conda", "install", "-n", "ldsc27", "-c", "bioconda", "bedtools", "-y"],
-            check=True
+            check=True,
         )
 
     if not LDSC_DIR.exists():
         subprocess.run(
             ["git", "clone", "https://github.com/bulik/ldsc.git", str(LDSC_DIR)],
-            check=True
+            check=True,
         )
 
-    check_numpy = subprocess.run(
+    _check_np = subprocess.run(
         [os.path.join(ldsc27_path, "bin", "python"), "-c", "import numpy"],
-        capture_output=True
+        capture_output=True,
     )
-
-    if check_numpy.returncode != 0:
+    if _check_np.returncode != 0:
         subprocess.run(
             ["conda", "install", "-n", "ldsc27", "-y", "openssl=1.0.2", "-c", "conda-forge"],
-            check=True
+            check=True,
         )
         subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-y", "numpy", "scipy", "pandas", "bitarray", "-c", "conda-forge"],
-            check=True
+            ["conda", "install", "-n", "ldsc27", "-y",
+             "numpy", "scipy", "pandas", "bitarray", "-c", "conda-forge"],
+            check=True,
         )
         subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-y", "pybedtools", "pysam=0.15.3", "-c", "bioconda", "-c", "conda-forge"],
-            check=True
+            ["conda", "install", "-n", "ldsc27", "-y",
+             "pybedtools", "pysam=0.15.3", "-c", "bioconda", "-c", "conda-forge"],
+            check=True,
         )
 
-    ldsc_script = LDSC_DIR / "ldsc.py"
-    subprocess.run(["chmod", "+x", str(ldsc_script)], check=True)
+    subprocess.run(["chmod", "+x", str(LDSC_DIR / "ldsc.py")], check=True)
     python27_path = os.path.join(ldsc27_path, "bin", "python")
 
-    print(f"LDSC environment ready!")
-    print(f"Python 2.7 path: {python27_path}")
-    print(f"LDSC path: {ldsc_script}")
-
-    return (ldsc_script, python27_path, ldsc27_path)
+    print(f"LDSC environment ready")
+    print(f"Python 2.7 : {python27_path}")
+    print(f"LDSC dir   : {LDSC_DIR}")
+    return (TOOLS_DIR, LDSC_DIR, ldsc27_path, python27_path)
 
 
 @app.cell
@@ -140,123 +169,97 @@ def __(mo):
 
 
 @app.cell
-def __(os, urllib, pd, subprocess, re, GWAS_INPUT_FILE):
-    os.makedirs("data/peaks", exist_ok=True)
-    os.makedirs("data/reference", exist_ok=True)
-    os.makedirs("data/gwas", exist_ok=True)
-    os.makedirs("data/beds", exist_ok=True)
+def __(
+    os, urllib, pd, subprocess, re,
+    CATLAS_DIR, CATLAS_URL, BROAD_CELL_TYPES, BROAD_BASE_URL,
+    GWAS_FILE,
+):
+    for _d in ["data/peaks", "data/reference", "data/gwas", "data/beds"]:
+        os.makedirs(_d, exist_ok=True)
 
-    BROAD_CELL_TYPES = ["Ast", "Ex", "In", "Microglia", "OPC", "Oligo", "PerEndo"]
-    BROAD_BASE_URL = "https://personal.broadinstitute.org/bjames/AD_snATAC/major_celltype_matrices/"
-
-    CATLAS_DIR = "humanenhancer_atac_data"
-    CATLAS_URL = "http://catlas.org/humanenhancer/data/cCREs/"
     BED_SEARCH_DIRS = [CATLAS_DIR, "data/beds"]
 
-    def _sanitize_name(raw_name):
-        return re.sub(r'[^A-Za-z0-9_\-]', '_', raw_name)
+    def _sanitize(name):
+        return re.sub(r"[^A-Za-z0-9_\-]", "_", name)
 
-    def _ensure_catlas_downloaded():
-        bed_files = [
-            f for f in os.listdir(CATLAS_DIR)
-            if f.endswith(".bed") and not f.startswith(".")
-        ] if os.path.exists(CATLAS_DIR) else []
-        if bed_files:
-            print(f"{CATLAS_DIR} already has {len(bed_files)} BED files, skipping download")
-            return
-        print(f"Downloading all cell type BEDs from {CATLAS_URL}")
+    def _ensure_catlas():
+        if os.path.exists(CATLAS_DIR):
+            _beds = [f for f in os.listdir(CATLAS_DIR) if f.endswith(".bed")]
+            if _beds:
+                print(f"{CATLAS_DIR} has {len(_beds)} BED files, skipping download")
+                return
         os.makedirs(CATLAS_DIR, exist_ok=True)
         subprocess.run(
-            ["wget", "-r", "-np", "-nH", "--cut-dirs=3", "-R", "index.html*", "-P", CATLAS_DIR, CATLAS_URL],
-            check=True
+            ["wget", "-r", "-np", "-nH", "--cut-dirs=3",
+             "-R", "index.html*", "-P", CATLAS_DIR, CATLAS_URL],
+            check=True,
         )
-        downloaded = [f for f in os.listdir(CATLAS_DIR) if f.endswith(".bed")]
-        print(f"Downloaded {len(downloaded)} BED files to {CATLAS_DIR}/")
+        print(f"Downloaded {len([f for f in os.listdir(CATLAS_DIR) if f.endswith('.bed')])} BED files")
 
-    def _find_local_bed(raw_name):
+    def _find_local_bed(name):
         for d in BED_SEARCH_DIRS:
-            candidate = os.path.join(d, f"{raw_name}.bed")
-            if os.path.exists(candidate):
-                return candidate
+            p = os.path.join(d, f"{name}.bed")
+            if os.path.exists(p):
+                return p
         return None
 
-    def _peak_annotation_to_bed(ct):
+    def _peak_to_bed(ct):
         peak_txt = f"data/peaks/{ct}.peak.annotation.txt"
-        bed_out = f"data/beds/{ct}.bed"
+        bed_out  = f"data/beds/{ct}.bed"
         if os.path.exists(bed_out):
             return bed_out
         if not os.path.exists(peak_txt):
-            url = f"{BROAD_BASE_URL}{ct}.peak.annotation.txt"
-            print(f"  Downloading peak annotation for {ct}...")
-            urllib.request.urlretrieve(url, peak_txt)
-        peaks = pd.read_csv(peak_txt, sep="\t")
-        _bed = peaks[['seqnames', 'start', 'end']].copy()
-        _bed.columns = ['chr', 'start', 'end']
-        _bed.to_csv(bed_out, sep="\t", index=False, header=False)
+            urllib.request.urlretrieve(f"{BROAD_BASE_URL}{ct}.peak.annotation.txt", peak_txt)
+        _peaks = pd.read_csv(peak_txt, sep="\t")
+        _peaks[["seqnames", "start", "end"]].rename(
+            columns={"seqnames": "chr"}
+        ).to_csv(bed_out, sep="\t", index=False, header=False)
         return bed_out
 
-    _ensure_catlas_downloaded()
+    _ensure_catlas()
 
     raw_names = set()
-    for _d in BED_SEARCH_DIRS:
-        if os.path.exists(_d):
-            for _f in os.listdir(_d):
+    for _sd in BED_SEARCH_DIRS:
+        if os.path.exists(_sd):
+            for _f in os.listdir(_sd):
                 if _f.endswith(".bed") and not _f.startswith("."):
                     raw_names.add(os.path.splitext(_f)[0])
-    for _ct in BROAD_CELL_TYPES:
-        raw_names.add(_ct)
-
-    print(f"Resolving BED files for {len(raw_names)} cell types")
+    raw_names.update(BROAD_CELL_TYPES)
 
     cell_type_beds = {}
-    name_conflicts = {}
-
+    _seen = {}
     for _raw in sorted(raw_names):
-        _safe = _sanitize_name(_raw)
-        if _safe in name_conflicts:
-            _safe = _safe + "_2"
-        name_conflicts[_safe] = _raw
-
+        _safe = _sanitize(_raw)
+        if _safe in _seen:
+            _safe += "_2"
+        _seen[_safe] = _raw
         _local = _find_local_bed(_raw)
-        if _local:
-            cell_type_beds[_safe] = _local
-            print(f"  {_safe}  ->  {_local}")
-        else:
-            _bed = _peak_annotation_to_bed(_raw)
-            cell_type_beds[_safe] = _bed
-            print(f"  {_safe}  ->  {_bed}  (converted from peak annotation)")
+        cell_type_beds[_safe] = _local if _local else _peak_to_bed(_raw)
 
     all_cell_types = sorted(cell_type_beds.keys())
-    print(f"\n{len(all_cell_types)} cell types ready")
+    print(f"{len(all_cell_types)} cell types ready")
 
-    if not os.path.exists("data/reference/GRCh38.tgz"):
-        print("Downloading GRCh38 reference...")
-        urllib.request.urlretrieve(
+    for _url, _dst in [
+        (
             "https://zenodo.org/records/10515792/files/GRCh38.tgz?download=1",
-            "data/reference/GRCh38.tgz"
-        )
-
-    if not os.path.exists("data/reference/hm3_no_MHC.list.txt"):
-        print("Downloading HapMap3 SNP list...")
-        urllib.request.urlretrieve(
+            "data/reference/GRCh38.tgz",
+        ),
+        (
             "https://zenodo.org/records/10515792/files/hm3_no_MHC.list.txt?download=1",
-            "data/reference/hm3_no_MHC.list.txt"
-        )
+            "data/reference/hm3_no_MHC.list.txt",
+        ),
+    ]:
+        if not os.path.exists(_dst):
+            print(f"Downloading {_dst}...")
+            urllib.request.urlretrieve(_url, _dst)
 
-    if not os.path.exists(GWAS_INPUT_FILE):
-        print(f"Downloading GWAS summary statistics to {GWAS_INPUT_FILE}...")
-        urllib.request.urlretrieve(
-            "http://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics/GCST90027001-GCST90028000/GCST90027158/GCST90027158_buildGRCh38.tsv.gz",
-            GWAS_INPUT_FILE
-        )
-
-    print("\nAll sources resolved!")
-    return (all_cell_types, cell_type_beds)
+    print("All sources resolved")
+    return (all_cell_types, cell_type_beds, BED_SEARCH_DIRS)
 
 
 @app.cell
 def __(mo):
-    mo.md("## 2. Extract reference LD panels and baseline LD scores")
+    mo.md("## 2. Extract reference LD panels")
     return
 
 
@@ -265,278 +268,156 @@ def __(subprocess, os):
     if not os.path.exists("data/reference/GRCh38"):
         subprocess.run(
             ["tar", "-xzf", "data/reference/GRCh38.tgz", "-C", "data/reference"],
-            check=True
+            check=True,
         )
 
-    nested_files = [
-        ("data/reference/GRCh38/baselineLD_v2.2.tgz", "data/reference", "baselineLD_v2.2"),
-        ("data/reference/GRCh38/plink_files.tgz", "data/reference/GRCh38", "plink_files/1000G.EUR.hg38.1.bim"),
-        ("data/reference/GRCh38/weights.tgz", "data/reference/GRCh38", "weights")
-    ]
-
-    for tar_file, extract_to, check_file in nested_files:
-        _check_path = os.path.join(extract_to, check_file)
-        if os.path.exists(_check_path):
-            continue
-        if os.path.exists(tar_file):
-            subprocess.run(["tar", "-xzf", tar_file, "-C", extract_to], check=True)
+    for _tgz, _base, _check in [
+        (
+            "data/reference/GRCh38/plink_files.tgz",
+            "data/reference/GRCh38",
+            "plink_files/1000G.EUR.hg38.1.bim",
+        ),
+        (
+            "data/reference/GRCh38/weights.tgz",
+            "data/reference/GRCh38",
+            "weights",
+        ),
+    ]:
+        if not os.path.exists(os.path.join(_base, _check)) and os.path.exists(_tgz):
+            subprocess.run(["tar", "-xzf", _tgz, "-C", _base], check=True)
 
     _critical = "data/reference/GRCh38/plink_files/1000G.EUR.hg38.1.bim"
-    if os.path.exists(_critical):
-        print("All reference files ready!")
-    else:
-        print(f"ERROR: Critical file missing: {_critical}")
-
+    print("Reference files ready" if os.path.exists(_critical) else f"ERROR: missing {_critical}")
     return
 
 
 @app.cell
 def __(mo):
-    mo.md("## 3. Convert GWAS to GWAS-SSF format")
+    mo.md("## 3. Munge GWAS summary statistics")
     return
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, datetime):
-    os.makedirs("data/ssf", exist_ok=True)
+def __(
+    GWAS_FILE, PREMUNGE_FILE, SUMSTATS_FILE, MUNGE_PREFIX,
+    W_HM3_SNPLIST, python27_path, pd, os, subprocess, glob,
+):
+    import gzip as _gzip
 
-    if os.path.exists(SSF_FILE):
-        print(f"SSF file already exists, skipping: {SSF_FILE}")
-    else:
-        print(f"Converting {GWAS_INPUT_FILE} -> {SSF_FILE}")
-
-        _compression = "gzip" if GWAS_INPUT_FILE.endswith((".gz", ".bgz")) else None
-        _sep = r"\s+" if GWAS_INPUT_FILE.endswith((".txt", ".txt.gz")) else "\t"
-        _engine = "c" if GWAS_INPUT_FILE.endswith(".bgz") else "python"
-        _df = pd.read_csv(GWAS_INPUT_FILE, sep=_sep, compression=_compression, engine=_engine)
-
-        print(f"  Columns detected: {list(_df.columns)}")
-
-        _has_hm = any(c.startswith("hm_") for c in _df.columns) and _df['hm_chrom'].notna().any()
-
-        if _has_hm:
-            print("Detected GWAS Catalog harmonised format (hm_ columns)")
-            _df2 = pd.DataFrame()
-            _df2['chromosome']              = _df['hm_chrom'].astype(str)
-            _df2['base_pair_location']      = pd.to_numeric(_df['hm_pos'], errors='coerce')
-            _df2['effect_allele']           = _df['hm_effect_allele'].str.upper()
-            _df2['other_allele']            = _df['hm_other_allele'].str.upper()
-            _df2['beta']                    = pd.to_numeric(_df['hm_beta'], errors='coerce')
-            _df2['standard_error']          = pd.to_numeric(_df['standard_error'], errors='coerce')
-            _df2['p_value']                 = pd.to_numeric(_df['p_value'], errors='coerce')
-            _df2['effect_allele_frequency'] = pd.to_numeric(_df['hm_effect_allele_frequency'], errors='coerce').fillna('NA')
-            _df2['rsid']                    = _df['hm_rsid'].fillna('NA')
-            _df = _df2
-        else:
-            _cols_lower = {col.lower(): col for col in _df.columns}
-
-            if "variant" in _cols_lower:
-                print("Detected Neale format")
-                _df[['chromosome', 'base_pair_location', 'other_allele', 'effect_allele']] = \
-                    _df[_cols_lower['variant']].str.split(':', expand=True)
-                _cols_lower = {col.lower(): col for col in _df.columns}
-                _col_map = {}
-                _col_map['standard_error'] = _cols_lower.get('se') or _cols_lower.get('stderr')
-                _col_map['p_value']        = _cols_lower.get('pval') or _cols_lower.get('p_value') or _cols_lower.get('p')
-                _col_map['n_total']        = _cols_lower.get('n_complete_samples') or _cols_lower.get('n') or _cols_lower.get('n_total')
-                _col_map['effect_allele_frequency'] = _cols_lower.get('minor_af') or _cols_lower.get('af') or _cols_lower.get('freq')
-                _rename_map = {v: k for k, v in _col_map.items() if v is not None}
-                _df = _df.rename(columns=_rename_map)
-            else:
-                print("Detected PLINK/standard format")
-                _col_map = {}
-                _col_map['chromosome']              = _cols_lower.get('chr') or _cols_lower.get('chrom') or _cols_lower.get('chromosome')
-                _col_map['base_pair_location']      = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
-                _col_map['effect_allele']           = _cols_lower.get('a1') or _cols_lower.get('effect_allele') or _cols_lower.get('allele1') or _cols_lower.get('alt')
-                _col_map['other_allele']            = _cols_lower.get('a2') or _cols_lower.get('other_allele') or _cols_lower.get('allele2') or _cols_lower.get('ref')
-                _col_map['beta']                    = _cols_lower.get('beta') or _cols_lower.get('logor') or _cols_lower.get('log_odds') or _cols_lower.get('effect')
-                _col_map['standard_error']          = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error') or _cols_lower.get('stderrlogor') or _cols_lower.get('se_beta')
-                _col_map['p_value']                 = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value') or _cols_lower.get('pvalue') or _cols_lower.get('p.value')
-                _col_map['effect_allele_frequency'] = _cols_lower.get('freq') or _cols_lower.get('a1_freq') or _cols_lower.get('frq') or _cols_lower.get('af') or _cols_lower.get('eaf') or _cols_lower.get('effect_allele_frequency')
-                _col_map['rsid']                    = _cols_lower.get('markername') or _cols_lower.get('snp') or _cols_lower.get('rsid') or _cols_lower.get('id') or _cols_lower.get('variant_id') or _cols_lower.get('snpid')
-                _col_map['n_total']                 = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('n_samples') or _cols_lower.get('sample_size') or _cols_lower.get('neff')
-
-                _rename_map = {v: k for k, v in _col_map.items() if v is not None}
-                _df = _df.rename(columns=_rename_map)
-
-                if 'effect_allele' in _df.columns:
-                    _df['effect_allele'] = _df['effect_allele'].astype(str).str.upper()
-                if 'other_allele' in _df.columns:
-                    _df['other_allele'] = _df['other_allele'].astype(str).str.upper()
-
-        if 'chromosome' in _df.columns:
-            _df['chromosome'] = _df['chromosome'].astype(str).str.replace('chr', '', regex=False).str.strip()
-            _df['chromosome'] = _df['chromosome'].replace({'23': 'X', '24': 'Y', '26': 'MT'})
-            _before = len(_df)
-            _df = _df[~_df['chromosome'].isin(['X', 'Y', 'MT', 'nan', 'None', ''])]
-            _df = _df.dropna(subset=['chromosome', 'base_pair_location'])
-            _df = _df[_df['chromosome'].astype(str).str.strip().str.match(r'^\d+$')]
-            print(f"  Removed {_before - len(_df)} variants on sex/MT/invalid chromosomes")
-        else:
-            print("  No chromosome column found — will use rsID for SNP matching")
-
-        if 'effect_allele_frequency' not in _df.columns:
-            _df['effect_allele_frequency'] = 'NA'
-        else:
-            _df['effect_allele_frequency'] = _df['effect_allele_frequency'].fillna('NA')
-
-        if 'rsid' not in _df.columns:
-            _df['rsid'] = 'NA'
-        else:
-            _df['rsid'] = _df['rsid'].fillna('NA')
-
-        _ssf_cols = ['chromosome', 'base_pair_location', 'effect_allele', 'other_allele',
-                     'beta', 'standard_error', 'p_value', 'effect_allele_frequency', 'rsid']
-        if 'n_total' in _df.columns:
-            _ssf_cols.append('n_total')
-
-        _df_ssf = _df[[c for c in _ssf_cols if c in _df.columns]]
-
-        print(f"  SSF columns: {list(_df_ssf.columns)}")
-        print(f"  SSF rows: {len(_df_ssf)}")
-
-        _df_ssf.to_csv(SSF_FILE, sep="\t", index=False, compression="gzip")
-
-        subprocess.run(
-            ["tabix", "-c", "N", "-S", "1", "-s", "1", "-b", "2", "-e", "2", SSF_FILE],
-            check=False
-        )
-
-        with gzip.open(SSF_FILE, 'rb') as _f:
-            _md5 = hashlib.md5(_f.read()).hexdigest()
-
-        with open(SSF_YAML, 'w') as _f:
-            _f.write(f"""# Study meta-data
-date_metadata_last_modified: {datetime.now().strftime('%Y-%m-%d')}
-genome_assembly: GRCh38
-coordinate_system: 1-based
-data_file_name: {os.path.basename(SSF_FILE)}
-file_type: GWAS-SSF v0.1
-data_file_md5sum: {_md5}
-is_harmonised: false
-is_sorted: false
-""")
-        print("SSF conversion complete")
-
-    return
-
-
-@app.cell
-def __(mo):
-    mo.md("## 4. Convert SSF to LDSC format")
-    return
-
-
-@app.cell
-def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
     os.makedirs("data/ldsc_input", exist_ok=True)
+    os.makedirs("data/munging_input", exist_ok=True)
 
     if os.path.exists(SUMSTATS_FILE):
-        print(f"LDSC sumstats file already exists: {SUMSTATS_FILE}")
+        print(f"Munged sumstats already exists, skipping: {SUMSTATS_FILE}")
     else:
-        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}")
+        if not os.path.exists(PREMUNGE_FILE):
+            _skip = 0
+            with _gzip.open(GWAS_FILE, "rt") as _fh:
+                for _line in _fh:
+                    if _line.startswith("##"):
+                        _skip += 1
+                    else:
+                        break
 
-        _df = pd.read_csv(SSF_FILE, sep='\t', compression='gzip')
-        print(f"Input: {len(_df)} variants")
+            _df = pd.read_csv(GWAS_FILE, sep="\t", compression="gzip", skiprows=_skip)
+            _df.columns = [c.lstrip("#").strip() for c in _df.columns]
+            print(f"  Columns: {list(_df.columns)}")
 
-        _ldsc = pd.DataFrame()
+            _cl = {c.lower(): c for c in _df.columns}
 
-        _has_rsid = 'rsid' in _df.columns and (_df['rsid'] != 'NA').any() and _df['rsid'].notna().any()
-        _has_chrpos = 'chromosome' in _df.columns and 'base_pair_location' in _df.columns
+            _rsid_col  = _cl.get("id") or _cl.get("snp") or _cl.get("rsid") or _cl.get("variant_id")
+            _a1_col    = _cl.get("a1") or _cl.get("alt") or _cl.get("effect_allele")
+            _a2_col    = _cl.get("a2") or _cl.get("ref") or _cl.get("reference") or _cl.get("other_allele")
+            _beta_col  = _cl.get("beta") or _cl.get("b") or _cl.get("logor")
+            _se_col    = _cl.get("se") or _cl.get("stderr") or _cl.get("standard_error")
+            _p_col     = _cl.get("pval") or _cl.get("pvalue") or _cl.get("p_value") or _cl.get("p")
+            _n_col     = _cl.get("neff") or _cl.get("n") or _cl.get("n_total") or _cl.get("sample_size")
 
-        if _has_rsid:
-            _ldsc['SNP'] = _df['rsid'].astype(str)
-            if _has_chrpos:
-                _missing = (_ldsc['SNP'].isna()) | (_ldsc['SNP'] == 'NA') | (_ldsc['SNP'] == 'nan')
-                _ldsc.loc[_missing, 'SNP'] = (
-                    _df.loc[_missing, 'chromosome'].astype(float).astype(int).astype(str) + ':' +
-                    _df.loc[_missing, 'base_pair_location'].astype(float).astype(int).astype(str)
+            _df = _df.rename(columns={
+                _a1_col: "A1", _a2_col: "A2", _beta_col: "BETA",
+                _se_col: "SE", _p_col: "P", _n_col: "N",
+            })
+
+            if _rsid_col and _df[_rsid_col].astype(str).str.match(r"^rs\d+$", na=False).sum() > 0:
+                _df["SNP"] = _df[_rsid_col]
+            else:
+                _bim_map = pd.concat([
+                    pd.read_csv(f, sep="\t", header=None, names=["CHR","SNP","CM","BP","A1b","A2b"])
+                    .assign(key=lambda x: x["CHR"].astype(str) + ":" + x["BP"].astype(str))[["key","SNP"]]
+                    for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
+                ]).drop_duplicates("key").set_index("key")["SNP"]
+                _varid = _cl.get("varid") or _cl.get("variant")
+                _df["key"] = _df[_varid].str.split(":").str[:2].str.join(":") if _varid else (
+                    _df[_cl.get("chrom") or _cl.get("chr")].astype(str).str.replace("chr","",regex=False)
+                    + ":" + _df[_cl.get("pos") or _cl.get("position")].astype(str)
                 )
-        elif _has_chrpos:
-            _ldsc['SNP'] = (
-                _df['chromosome'].astype(float).astype(int).astype(str) + ':' +
-                _df['base_pair_location'].astype(float).astype(int).astype(str)
+                _df["SNP"] = _df["key"].map(_bim_map)
+                _df = _df.drop(columns=["key"])
+
+            _keep = [c for c in ["SNP","A1","A2","BETA","SE","P","N"] if c in _df.columns]
+            _df[_keep].dropna(subset=["SNP","A1","A2","BETA","P"]).to_csv(
+                PREMUNGE_FILE, sep="\t", index=False, compression="gzip"
             )
-        else:
-            raise ValueError("No SNP identifier found — need either rsid or chromosome:position columns")
+            print(f"  Written {len(_df):,} variants to {PREMUNGE_FILE}")
 
-        _ldsc['A1'] = _df['effect_allele'].astype(str).str.upper()
-        _ldsc['A2'] = _df['other_allele'].astype(str).str.upper()
-        _ldsc['Z']  = pd.to_numeric(_df['beta'], errors='coerce') / pd.to_numeric(_df['standard_error'], errors='coerce')
-        _ldsc['N']  = 360527
-
-        if 'p_value' in _df.columns:
-            _ldsc['P'] = pd.to_numeric(_df['p_value'], errors='coerce')
-
-        _before = len(_ldsc)
-        _ldsc = _ldsc[np.isfinite(_ldsc['Z'])]
-        if _before > len(_ldsc):
-            print(f"Removed {_before - len(_ldsc)} variants with invalid Z-scores")
-
-        _before = len(_ldsc)
-        _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
-        if _before > len(_ldsc):
-            print(f"Removed {_before - len(_ldsc)} duplicate variants")
-
-        print(f"Output: {len(_ldsc)} variants")
-        print(f"  Sample SNP IDs: {list(_ldsc['SNP'].head(3))}")
-        _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
-
-        print(f"LDSC format conversion complete")
-        print(f"  Mean |Z|: {_ldsc['Z'].abs().mean():.3f}")
-        print(f"  Median |Z|: {_ldsc['Z'].abs().median():.3f}")
-        if 'P' in _ldsc.columns:
-            print(f"  Genome-wide significant (P < 5e-8): {(_ldsc['P'] < 5e-8).sum():,}")
+        _peek = pd.read_csv(PREMUNGE_FILE, sep="\t", compression="gzip", nrows=2)
+        subprocess.run([
+            python27_path, "tools/ldsc/munge_sumstats.py",
+            "--sumstats",        PREMUNGE_FILE,
+            "--out",             MUNGE_PREFIX,
+            "--snp",             "SNP",
+            "--a1",              "A1",
+            "--a2",              "A2",
+            "--signed-sumstats", "BETA,0",
+            "--p",               "P",
+            "--merge-alleles",   W_HM3_SNPLIST,
+        ] + (["--N-col", "N"] if "N" in _peek.columns else []), check=True)
+        print(f"Munging complete: {SUMSTATS_FILE}")
 
     return
 
 
 @app.cell
 def __(mo):
-    mo.md("## 5. Generate cell-type–specific binary annotations (BED → .annot.gz)")
+    mo.md("## 4. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
     return
 
 
 @app.cell
 def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_path):
     os.makedirs("data/annotations", exist_ok=True)
-
-    env = os.environ.copy()
-    env["PATH"] = f"{ldsc27_path}/bin:" + env.get("PATH", "")
+    _env = os.environ.copy()
+    _env["PATH"] = f"{ldsc27_path}/bin:" + _env.get("PATH", "")
 
     for _ct in all_cell_types:
-        print(f"\nProcessing {_ct}...")
         _all_exist = all(
-            os.path.exists(f"data/annotations/{_ct}.{_chrom}.annot.gz")
-            for _chrom in range(1, 23)
+            os.path.exists(f"data/annotations/{_ct}.{_ch}.annot.gz")
+            for _ch in range(1, 23)
         )
-
         if _all_exist:
-            print(f"  All {_ct} annotations already exist, skipping")
+            print(f"  {_ct}: all annotations exist, skipping")
             continue
 
-        _bed_file = cell_type_beds[_ct]
-
-        for _chrom in range(1, 23):
-            _annot_file = f"data/annotations/{_ct}.{_chrom}.annot.gz"
-            if os.path.exists(_annot_file):
-                print(f"  Chromosome {_chrom} (exists)", end=" ", flush=True)
+        print(f"\nProcessing {_ct}...")
+        _bed = cell_type_beds[_ct]
+        for _ch in range(1, 23):
+            _out = f"data/annotations/{_ct}.{_ch}.annot.gz"
+            if os.path.exists(_out):
                 continue
-
-            print(f"  Chromosome {_chrom}...", end=" ", flush=True)
-            _result = subprocess.run([
-                python27_path, "tools/ldsc/make_annot.py",
-                "--bed-file", _bed_file,
-                "--bimfile", f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_chrom}.bim",
-                "--annot-file", _annot_file
-            ], capture_output=True, text=True, env=env)
-
-            if _result.returncode != 0:
-                print(f"\nERROR on chromosome {_chrom}:")
-                print("STDERR:", _result.stderr)
-                raise subprocess.CalledProcessError(_result.returncode, _result.args)
-            print("done")
-        print(f"  {_ct} complete")
+            _r = subprocess.run(
+                [
+                    python27_path, "tools/ldsc/make_annot.py",
+                    "--bed-file",   _bed,
+                    "--bimfile",    f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_ch}.bim",
+                    "--annot-file", _out,
+                ],
+                capture_output=True, text=True, env=_env,
+            )
+            if _r.returncode != 0:
+                print(f"  ERROR chr {_ch}: {_r.stderr}")
+                raise subprocess.CalledProcessError(_r.returncode, _r.args)
+            print(f"  chr{_ch}", end=" ", flush=True)
+        print(f"\n  {_ct} done")
 
     print("\nAll annotations generated")
     return
@@ -544,154 +425,147 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
 
 @app.cell
 def __(mo):
-    mo.md("## 6. Calculate LD scores for each cell type and chromosome (HapMap3 SNPs only)")
+    mo.md("## 5. Calculate LD scores (HapMap3 SNPs only)")
     return
 
 
 @app.cell
-def __(subprocess, os, all_cell_types, python27_path):
-    import concurrent.futures
-    import multiprocessing
-
+def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessing, HM3_NO_MHC_LIST):
     os.makedirs("data/ldscores", exist_ok=True)
-    HM3_SNP_LIST = "data/reference/hm3_no_MHC.list.txt"
 
-    def calculate_single_chrom(args):
-        ct, chrom = args
-        out_dir = f"data/ldscores/{ct}"
-        os.makedirs(out_dir, exist_ok=True)
-
-        ldscore_file = f"{out_dir}/{ct}.{chrom}.l2.ldscore.gz"
-        if os.path.exists(ldscore_file):
-            return f"[{ct}] Chr {chrom} already exists. Skipping."
-
+    def _calc_ld(args):
+        ct, ch = args
+        _dir  = f"data/ldscores/{ct}"
+        os.makedirs(_dir, exist_ok=True)
+        _out  = f"{_dir}/{ct}.{ch}.l2.ldscore.gz"
+        if os.path.exists(_out):
+            return f"[{ct}] chr{ch} exists"
         try:
-            subprocess.run([
-                python27_path, "tools/ldsc/ldsc.py",
-                "--l2",
-                "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{chrom}",
-                "--ld-wind-cm", "1.0",
-                "--annot",      f"data/annotations/{ct}.{chrom}.annot.gz",
-                "--thin-annot",
-                "--print-snps", HM3_SNP_LIST,
-                "--out",        f"{out_dir}/{ct}.{chrom}"
-            ], check=True, capture_output=True)
-            return f"[{ct}] Chr {chrom} calculation complete."
+            subprocess.run(
+                [
+                    python27_path, "tools/ldsc/ldsc.py",
+                    "--l2",
+                    "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{ch}",
+                    "--ld-wind-cm", "1.0",
+                    "--annot",      f"data/annotations/{ct}.{ch}.annot.gz",
+                    "--thin-annot",
+                    "--print-snps", HM3_NO_MHC_LIST,
+                    "--out",        f"{_dir}/{ct}.{ch}",
+                ],
+                check=True, capture_output=True,
+            )
+            return f"[{ct}] chr{ch} done"
         except subprocess.CalledProcessError as e:
-            return f"ERROR on [{ct}] Chr {chrom}: {e.stderr}"
+            return f"ERROR [{ct}] chr{ch}: {e.stderr}"
 
-    tasks = []
-    for ct in all_cell_types:
-        for chrom in range(1, 23):
-            tasks.append((ct, chrom))
-    max_workers = min(multiprocessing.cpu_count() - 1, 6)
+    _tasks      = [(ct, ch) for ct in all_cell_types for ch in range(1, 23)]
+    _max_workers = min(multiprocessing.cpu_count() - 1, 6)
+    print(f"Running LD score calculation ({_max_workers} workers, {len(_tasks)} tasks)...")
 
-    print(f"Starting parallel LDSC calculation with {max_workers} workers...")
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for result in executor.map(calculate_single_chrom, tasks):
-            print(result)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _ex:
+        for _res in _ex.map(_calc_ld, _tasks):
+            print(_res)
 
-    print("\nAll LD scores calculated using HapMap3 SNPs")
+    print("\nAll LD scores calculated")
     return
 
 
 @app.cell
 def __(mo):
-    mo.md("## 7. Create CTS (cell-type–specific) reference file")
+    mo.md("## 6. Create CTS reference file")
     return
 
 
 @app.cell
-def __(os, all_cell_types, GWAS_STEM):
+def __(os, all_cell_types, GWAS_STEM, CTS_FILE):
     os.makedirs("results", exist_ok=True)
-    cts_path = f"data/{GWAS_STEM}_cell_types.cts"
 
     COMPLETED_CELL_TYPES = []
     for _ct in all_cell_types:
-        _all_exist = all(
-            os.path.exists(f"data/ldscores/{_ct}/{_ct}.{_chrom}.l2.ldscore.gz")
-            for _chrom in range(1, 23)
+        _complete = all(
+            os.path.exists(f"data/ldscores/{_ct}/{_ct}.{_ch}.l2.ldscore.gz")
+            for _ch in range(1, 23)
         )
-        if _all_exist:
+        if _complete:
             COMPLETED_CELL_TYPES.append(_ct)
-            print(f"  {_ct}: complete")
         else:
-            _missing = [c for c in range(1, 23) if not os.path.exists(f"data/ldscores/{_ct}/{_ct}.{c}.l2.ldscore.gz")]
-            print(f"  {_ct}: INCOMPLETE (missing chromosomes: {_missing})")
+            _missing = [c for c in range(1, 23)
+                        if not os.path.exists(f"data/ldscores/{_ct}/{_ct}.{c}.l2.ldscore.gz")]
+            print(f"  {_ct}: INCOMPLETE — missing chr {_missing}")
 
-    with open(cts_path, "w") as _f:
+    with open(CTS_FILE, "w") as _f:
         for _ct in COMPLETED_CELL_TYPES:
             _f.write(f"{_ct}\tdata/ldscores/{_ct}/{_ct}.\n")
 
-    print(f"\nCTS file written with {len(COMPLETED_CELL_TYPES)} complete cell types: {cts_path}")
-    return (cts_path, COMPLETED_CELL_TYPES)
+    print(f"\nCTS file written: {CTS_FILE}  ({len(COMPLETED_CELL_TYPES)} cell types)")
+    return (COMPLETED_CELL_TYPES,)
 
 
 @app.cell
 def __(mo):
-    mo.md("## 8. Run LDSC cell-type–specific heritability analysis (CTS)")
+    mo.md("## 7. Run LDSC cell-type-specific heritability analysis")
     return
 
 
 @app.cell
-def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
-
-    _final_output = f"{RESULTS_PREFIX}.cell_type_results"
-
+def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
     if not os.path.exists(SUMSTATS_FILE):
-        print(f"Skipping - sumstats file not found: {SUMSTATS_FILE}")
-
-    elif not os.path.exists(cts_path):
-        print(f"Skipping - CTS file not found: {cts_path}")
-
-    elif os.path.exists(_final_output):
-        print(f"Results already exist, skipping: {_final_output}")
-
+        print(f"Skipping — sumstats not found: {SUMSTATS_FILE}")
+    elif not os.path.exists(CTS_FILE):
+        print(f"Skipping — CTS file not found: {CTS_FILE}")
     else:
         os.makedirs("results", exist_ok=True)
-        print("Running LDSC cell-type–specific heritability analysis...")
+        print("Running LDSC CTS analysis...")
+        subprocess.run(
+            [
+                python27_path, "tools/ldsc/ldsc.py",
+                "--h2-cts",         SUMSTATS_FILE,
+                "--ref-ld-chr",     (
+                    "data/reference/GRCh38/baselineLD_v2.2/baselineLD.,"
+                    "data/ldscores/all_merged_cCREs/all_merged_cCREs."
+                ),
+                "--ref-ld-chr-cts", CTS_FILE,
+                "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
+                "--out",            RESULTS_PREFIX,
+            ],
+            check=True,
+        )
+        print("LDSC CTS analysis complete")
+    return
 
-        subprocess.run([
-            python27_path, "tools/ldsc/ldsc.py",
-            "--h2-cts",         SUMSTATS_FILE,
-            "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
-            "--ref-ld-chr-cts", cts_path,
-            "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
-            "--out",            RESULTS_PREFIX,
-        ], check=True)
 
-        print("LDSC CTS analysis completed")
-
+@app.cell
+def __(mo):
+    mo.md("## 8. Results")
     return
 
 
 @app.cell
 def __(RESULTS_PREFIX, pd, os):
-    results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
+    from statsmodels.stats.multitest import fdrcorrection as _fdr
 
-    if not os.path.exists(results_file):
-        print(f"Results file not found: {results_file}")
+    _results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
+
+    if not os.path.exists(_results_file):
+        print(f"Results file not found: {_results_file}")
         ranked = None
     else:
-        results = pd.read_csv(results_file, sep="\t")
+        _results = pd.read_csv(_results_file, sep="\t")
+        _, _results["FDR"] = _fdr(_results["Coefficient_P_value"].fillna(1))
+        ranked = _results.sort_values("Coefficient_P_value")
 
-        ranked = results.sort_values("Coefficient_P_value")
-
-        ranked_csv = f"{RESULTS_PREFIX}_ranked_by_pvalue.csv"
-        ranked_txt = f"{RESULTS_PREFIX}_ranked_by_pvalue.txt"
-
-        ranked.to_csv(ranked_csv, index=False)
-        ranked.to_csv(ranked_txt, sep="\t", index=False)
+        ranked.to_csv(f"{RESULTS_PREFIX}_ranked.csv", index=False)
+        ranked.to_csv(f"{RESULTS_PREFIX}_ranked.txt", sep="\t", index=False)
 
         print("\nTop enriched cell types:\n")
         print(
-            ranked[
-                ["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value"]
-            ].head(10).to_string(index=False)
+            ranked[["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value", "FDR"]]
+            .head(15)
+            .to_string(index=False)
         )
+        print(f"\nFDR < 0.05: {(ranked['FDR'] < 0.05).sum()} cell types")
+        print(f"Saved to  : {RESULTS_PREFIX}_ranked.csv")
 
-        print(f"\nRanked CSV saved to: {ranked_csv}")
-        print(f"Ranked TXT saved to: {ranked_txt}")
     return (ranked,)
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.9.14"
 app = marimo.App(width="medium")
 
 
 @app.cell
-def _():
+def __():
     import marimo as mo
     import urllib.request
     import os
@@ -20,25 +19,11 @@ def _():
     import glob
     import concurrent.futures
     import multiprocessing
-
-    return (
-        Path,
-        concurrent,
-        glob,
-        json,
-        mo,
-        multiprocessing,
-        np,
-        os,
-        pd,
-        re,
-        subprocess,
-        urllib,
-    )
+    return mo, urllib, os, re, subprocess, pd, np, Path, json, glob, concurrent, multiprocessing
 
 
 @app.cell
-def _(mo):
+def __(mo):
     mo.md("""
     This notebook reproduces the LDSC cell-type-specific heritability analysis
     from *A single-cell atlas of chromatin accessibility in the human genome* (Zhang et al. 2021).
@@ -52,7 +37,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
+def __(mo, os):
     GWAS_INPUT_FILE = mo.ui.text(
         value="data/gwas/PASS_AtrialFibrillation_Nielsen2018.sumstats.gz",
         label="GWAS input file path",
@@ -69,16 +54,16 @@ def _(mo):
         mo.md(f"w_hm3.snplist: `{W_HM3_SNPLIST}`"),
     ])
     return (
-        CATLAS_DIR,
-        CATLAS_URL,
         GWAS_INPUT_FILE,
-        HM3_NO_MHC_LIST,
         W_HM3_SNPLIST,
+        HM3_NO_MHC_LIST,
+        CATLAS_DIR,
+        CATLAS_URL
     )
 
 
 @app.cell
-def _(GWAS_INPUT_FILE, os, re):
+def __(GWAS_INPUT_FILE, os, re):
     _path = GWAS_INPUT_FILE.value
     _basename = os.path.basename(_path)
     _no_ext = _basename
@@ -96,19 +81,23 @@ def _(GWAS_INPUT_FILE, os, re):
     print(f"GWAS file      : {GWAS_FILE}")
     print(f"Sumstats file  : {SUMSTATS_FILE}")
     print(f"Results prefix : {RESULTS_PREFIX}")
-    return CTS_FILE, GWAS_FILE, RESULTS_PREFIX, SUMSTATS_FILE
+    return (
+        GWAS_STEM,
+        GWAS_FILE,
+        SUMSTATS_FILE,
+        CTS_FILE,
+        RESULTS_PREFIX,
+    )
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 0. Setup: download and configure LDSC
-    """)
+def __(mo):
+    mo.md("## 0. Setup: download and configure LDSC")
     return
 
 
 @app.cell
-def _(Path, json, os, subprocess):
+def __(Path, subprocess, os, json):
     TOOLS_DIR = Path("tools")
     LDSC_DIR  = TOOLS_DIR / "ldsc"
     TOOLS_DIR.mkdir(exist_ok=True)
@@ -161,19 +150,21 @@ def _(Path, json, os, subprocess):
     print(f"LDSC environment ready")
     print(f"Python 2.7 : {python27_path}")
     print(f"LDSC dir   : {LDSC_DIR}")
-    return ldsc27_path, python27_path
+    return (TOOLS_DIR, LDSC_DIR, ldsc27_path, python27_path)
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 1. Discover cell types and resolve BED sources
-    """)
+def __(mo):
+    mo.md("## 1. Discover cell types and resolve BED sources")
     return
 
 
 @app.cell
-def _(CATLAS_DIR, CATLAS_URL, os, pd, re, subprocess, urllib):
+def __(
+    os, urllib, pd, subprocess, re,
+    CATLAS_DIR, CATLAS_URL,
+    GWAS_FILE,
+):
     for _d in ["data/peaks", "data/reference", "data/gwas", "data/beds"]:
         os.makedirs(_d, exist_ok=True)
 
@@ -224,7 +215,6 @@ def _(CATLAS_DIR, CATLAS_URL, os, pd, re, subprocess, urllib):
                 if _f.endswith(".bed") and not _f.startswith("."):
                     raw_names.add(os.path.splitext(_f)[0])
 
-
     cell_type_beds = {}
     _seen = {}
     for _raw in sorted(raw_names):
@@ -253,19 +243,17 @@ def _(CATLAS_DIR, CATLAS_URL, os, pd, re, subprocess, urllib):
             urllib.request.urlretrieve(_url, _dst)
 
     print("All sources resolved")
-    return all_cell_types, cell_type_beds
+    return (all_cell_types, cell_type_beds, BED_SEARCH_DIRS)
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 2. Extract reference LD panels
-    """)
+def __(mo):
+    mo.md("## 2. Extract reference LD panels")
     return
 
 
 @app.cell
-def _(os, subprocess):
+def __(subprocess, os):
     if not os.path.exists("data/reference/GRCh38"):
         subprocess.run(
             ["tar", "-xzf", "data/reference/GRCh38.tgz", "-C", "data/reference"],
@@ -293,15 +281,13 @@ def _(os, subprocess):
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 3. Reformat GWAS to harmonizer-compatible format
-    """)
+def __(mo):
+    mo.md("## 3. Reformat GWAS to harmonizer-compatible format")
     return
 
 
 @app.cell
-def _(GWAS_FILE, SUMSTATS_FILE, glob, os, pd):
+def __(GWAS_FILE, pd, os, glob, SUMSTATS_FILE):
     import gzip as _gzip
     import shutil as _shutil
 
@@ -385,106 +371,51 @@ def _(GWAS_FILE, SUMSTATS_FILE, glob, os, pd):
                 REFORMATTED_GWAS, sep="\t", index=False, compression="gzip"
             )
             print(f"  Written {len(_df):,} variants to {REFORMATTED_GWAS}")
+
     return (REFORMATTED_GWAS,)
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 4. Setup harmonization workflow
-    """)
+def __(mo):
+    mo.md("## 4. Setup harmonization workflow")
     return
 
 
 @app.cell
-def _(SSF_FILE, SUMSTATS_FILE, np, os, pd):
-    import yaml
-    os.makedirs("data/ldsc_input", exist_ok=True)
+def __(os, Path):
+    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser"
+    HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser/data/gwas_harm_ref"
+    harmonizer_script    = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
 
-    def find_n_deep(obj):
-        if isinstance(obj, dict):
-            for k, v in obj.items():
-                low_key = str(k).lower()
-                if (('sample' in low_key and 'size' in low_key) or low_key == 'n') and isinstance(v, (int, float)):
-                    return int(v)
-            for v in obj.values():
-                result = find_n_deep(v)
-                if result: return result
-        elif isinstance(obj, list):
-            for item in obj:
-                result = find_n_deep(item)
-                if result: return result
-        return None
+    nextflow_env = {
+        **os.environ,
+        "PATH": "/mnt/hdd_1/rediet/hypothesis-generation-demo:/mnt/hdd_1/rediet/jdk-17/bin:" + os.environ.get("PATH", ""),
+        "JAVA_HOME": "/mnt/hdd_1/rediet/jdk-17",
+    }
 
-    if os.path.exists(SUMSTATS_FILE):
-        _df_sample = pd.read_csv(SSF_FILE, sep='\t', compression='gzip', nrows=5)
-        print(f"LDSC sumstats file already exists: {SUMSTATS_FILE}")
-        print("Note: Skipping full conversion as file is present.")
+    if not harmonizer_script.exists():
+        print(f"WARNING: harmonizer.sh not found at {harmonizer_script}")
+        harmonizer_ready = False
+    elif not os.path.isdir(HARMONIZER_REF_DIR):
+        print(f"WARNING: Reference directory not found at {HARMONIZER_REF_DIR}")
+        harmonizer_ready = False
     else:
-        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}")
-        _df = pd.read_csv(SSF_FILE, sep='\t', compression='gzip')
+        print(f"Harmonizer configuration found")
+        print(f"  Script   : {harmonizer_script}")
+        print(f"  Reference: {HARMONIZER_REF_DIR}")
+        harmonizer_ready = True
 
-        detected_n = None
-        for col in _df.columns:
-            low_col = col.lower()
-            if low_col == 'n' or ('sample' in low_col and 'size' in low_col):
-                detected_n = int(_df[col].max())
-                print(f"N DETECTION: Found N={detected_n} inside the TSV data columns.")
-                break
-        if detected_n is None:
-            file_id = os.path.basename(SSF_FILE).split('-')[0]
-            gwas_dir = os.path.join("data", "gwas")
-            if os.path.exists(gwas_dir):
-                for file in os.listdir(gwas_dir):
-                    if file_id in file and file.endswith(".yaml"):
-                        yaml_path = os.path.join(gwas_dir, file)
-                        with open(yaml_path, 'r') as f:
-                            meta = yaml.safe_load(f)
-                            detected_n = find_n_deep(meta)
-                            if detected_n:
-                                print(f"N DETECTION: Found N={detected_n} via YAML Deep Search ({file}).")
-                                break
-        if detected_n is None:
-            raise ValueError("UNIVERSAL ERROR: Sample size (N) not found in data or metadata.")
-        _df['n'] = detected_n
-        _ldsc = pd.DataFrame()
-        if 'rsid' in _df.columns and (_df['rsid'] != 'NA').any():
-            _ldsc['SNP'] = _df['rsid']
-        else:
-            _ldsc['SNP'] = _df['chromosome'].astype(str) + ':' + _df['base_pair_location'].astype(str)
+    return (HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, harmonizer_ready, harmonizer_script, nextflow_env)
 
-        _ldsc['A1'] = _df['effect_allele'].str.upper()
-        _ldsc['A2'] = _df['other_allele'].str.upper()
-        _ldsc['Z'] = _df['beta'] / _df['standard_error']
-        _ldsc['N'] = _df['n']
 
-        if 'p_value' in _df.columns:
-            _ldsc['P'] = _df['p_value']
-        _ldsc = _ldsc[np.isfinite(_ldsc['Z'])]
-        _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
-        _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
+@app.cell
+def __(mo):
+    mo.md("## 5. Harmonize GWAS summary statistics")
     return
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 5. Harmonize GWAS summary statistics
-    """)
-    return
-
-
-@app.cell
-def _(
-    HARMONIZER_CODE_REPO,
-    HARMONIZER_REF_DIR,
-    REFORMATTED_GWAS,
-    harmonizer_ready,
-    harmonizer_script,
-    nextflow_env,
-    os,
-    subprocess,
-):
+def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, REFORMATTED_GWAS, harmonizer_script, nextflow_env):
     os.makedirs("data/harmonized", exist_ok=True)
 
     harmonized_found = False
@@ -550,27 +481,36 @@ def _(
             harmonized_output_dir = None
         finally:
             os.chdir("../..")
+
     return (harmonized_output_dir,)
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 6. Convert harmonized output to LDSC format
-    """)
+def __(mo):
+    mo.md("## 6. Convert harmonized output to LDSC format")
     return
 
 
 @app.cell
-def _(
-    REFORMATTED_GWAS,
-    SUMSTATS_FILE,
-    W_HM3_SNPLIST,
-    harmonized_output_dir,
-    os,
-    pd,
-):
+def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST, REFORMATTED_GWAS):
+    import yaml as _yaml
+
     os.makedirs("data/ldsc_input", exist_ok=True)
+
+    def _find_n_deep(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                low_key = str(k).lower()
+                if (('sample' in low_key and 'size' in low_key) or low_key == 'n') and isinstance(v, (int, float)):
+                    return int(v)
+            for v in obj.values():
+                res = _find_n_deep(v)
+                if res: return res
+        elif isinstance(obj, list):
+            for item in obj:
+                res = _find_n_deep(item)
+                if res: return res
+        return None
 
     if harmonized_output_dir is None:
         print("Skipping - no harmonized data available")
@@ -615,9 +555,30 @@ def _(
             _df["A1"]   = _df["A1"].str.upper()
             _df["A2"]   = _df["A2"].str.upper()
             _df["Z"]    = _df["BETA"] / _df["SE"]
+
             if "N" not in _df.columns:
-                print("  No N column found — using study sample size N=807553")
-                _df["N"] = 807553
+                _detected_n = None
+                for _col in _df.columns:
+                    _low_col = _col.lower()
+                    if _low_col == 'n' or ('sample' in _low_col and 'size' in _low_col):
+                        _detected_n = int(_df[_col].max())
+                        print(f"  N detected from column '{_col}': {_detected_n}")
+                        break
+                if _detected_n is None:
+                    _file_id = os.path.basename(_harmonized_file).split('-')[0]
+                    _gwas_dir = os.path.join("data", "gwas")
+                    if os.path.exists(_gwas_dir):
+                        for _f in os.listdir(_gwas_dir):
+                            if _file_id in _f and _f.endswith(".yaml"):
+                                with open(os.path.join(_gwas_dir, _f), 'r') as _fh:
+                                    _detected_n = _find_n_deep(_yaml.safe_load(_fh))
+                                    if _detected_n:
+                                        print(f"  N detected from YAML ({_f}): {_detected_n}")
+                                        break
+                if _detected_n is None:
+                    print("  No N column found — using study sample size N=807553")
+                    _detected_n = 807553
+                _df["N"] = _detected_n
 
             _hm3 = pd.read_csv(W_HM3_SNPLIST, sep="\t")[["SNP", "A1", "A2"]]
             _df  = _df.merge(_hm3, on="SNP", suffixes=("", "_hm3"))
@@ -635,26 +596,18 @@ def _(
             _out.to_csv(SUMSTATS_FILE, sep="\t", index=False, compression="gzip")
             print(f"  Written {len(_out):,} SNPs to {SUMSTATS_FILE}")
             print(f"  Mean |Z|: {_out['Z'].abs().mean():.3f}")
+
     return
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 7. Generate cell-type-specific binary annotations (BED -> .annot.gz)
-    """)
+def __(mo):
+    mo.md("## 7. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
     return
 
 
 @app.cell
-def _(
-    all_cell_types,
-    cell_type_beds,
-    ldsc27_path,
-    os,
-    python27_path,
-    subprocess,
-):
+def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_path):
     os.makedirs("data/annotations", exist_ok=True)
     _env = os.environ.copy()
     _env["PATH"] = f"{ldsc27_path}/bin:" + _env.get("PATH", "")
@@ -694,23 +647,13 @@ def _(
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 8. Calculate LD scores (HapMap3 SNPs only)
-    """)
+def __(mo):
+    mo.md("## 8. Calculate LD scores (HapMap3 SNPs only)")
     return
 
 
 @app.cell
-def _(
-    HM3_NO_MHC_LIST,
-    all_cell_types,
-    concurrent,
-    multiprocessing,
-    os,
-    python27_path,
-    subprocess,
-):
+def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessing, HM3_NO_MHC_LIST):
     os.makedirs("data/ldscores", exist_ok=True)
 
     def _calc_ld(args):
@@ -751,15 +694,13 @@ def _(
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 9. Create CTS reference file
-    """)
+def __(mo):
+    mo.md("## 9. Create CTS reference file")
     return
 
 
 @app.cell
-def _(CTS_FILE, all_cell_types, os):
+def __(os, all_cell_types, CTS_FILE):
     os.makedirs("new_results", exist_ok=True)
 
     COMPLETED_CELL_TYPES = []
@@ -782,19 +723,17 @@ def _(CTS_FILE, all_cell_types, os):
             _f.write(f"{_ct}\tdata/ldscores/{_ct}/{_ct}.\n")
 
     print(f"\nCTS file written: {CTS_FILE}  ({len(COMPLETED_CELL_TYPES)} cell types)")
+    return (COMPLETED_CELL_TYPES,)
+
+
+@app.cell
+def __(mo):
+    mo.md("## 10. Run LDSC cell-type-specific heritability analysis")
     return
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 10. Run LDSC cell-type-specific heritability analysis
-    """)
-    return
-
-
-@app.cell
-def _(CTS_FILE, RESULTS_PREFIX, SUMSTATS_FILE, os, python27_path, subprocess):
+def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
     if not os.path.exists(SUMSTATS_FILE):
         print(f"Skipping — sumstats not found: {SUMSTATS_FILE}")
     elif not os.path.exists(CTS_FILE):
@@ -816,20 +755,18 @@ def _(CTS_FILE, RESULTS_PREFIX, SUMSTATS_FILE, os, python27_path, subprocess):
             ],
             check=False,
         )
-        print("LDSC CTS analysis complete") 
+        print("LDSC CTS analysis complete")
     return
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## 11. Results
-    """)
+def __(mo):
+    mo.md("## 11. Results")
     return
 
 
 @app.cell
-def _(RESULTS_PREFIX, os, pd):
+def __(RESULTS_PREFIX, pd, os):
     from statsmodels.stats.multitest import fdrcorrection as _fdr
 
     _results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
@@ -853,7 +790,8 @@ def _(RESULTS_PREFIX, os, pd):
         )
         print(f"\nFDR < 0.05: {(ranked['FDR'] < 0.05).sum()} cell types")
         print(f"Saved to  : {RESULTS_PREFIX}_ranked.csv")
-    return
+
+    return (ranked,)
 
 
 if __name__ == "__main__":

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -508,44 +508,52 @@ def __(mo):
 
 @app.cell
 def __(subprocess, os, all_cell_types, python27_path):
-    import concurrent.futures
+    from concurrent.futures import ProcessPoolExecutor
     import multiprocessing
 
     os.makedirs("data/ldscores", exist_ok=True)
     HM3_SNP_LIST = "data/reference/hm3_no_MHC.list.txt"
+
     def calculate_single_chrom(args):
-        ct, chrom = args
+        import os, subprocess
+        ct, chrom, py_path, hm3 = args
         out_dir = f"data/ldscores/{ct}"
         os.makedirs(out_dir, exist_ok=True)
-        
+
         ldscore_file = f"{out_dir}/{ct}.{chrom}.l2.ldscore.gz"
         if os.path.exists(ldscore_file):
-            return f"[{ct}] Chr {chrom} already exists. Skipping."
+            return f"[{ct}] Chr {chrom} skipped (exists)"
 
         try:
             subprocess.run([
-                python27_path, "tools/ldsc/ldsc.py",
+                py_path, "tools/ldsc/ldsc.py",
                 "--l2",
                 "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{chrom}",
                 "--ld-wind-cm", "1.0",
                 "--annot",      f"data/annotations/{ct}.{chrom}.annot.gz",
                 "--thin-annot",
-                "--print-snps", HM3_SNP_LIST,
+                "--print-snps", hm3,
                 "--out",        f"{out_dir}/{ct}.{chrom}"
             ], check=True, capture_output=True)
-            return f"[{ct}] Chr {chrom} calculation complete."
+            return f"[{ct}] Chr {chrom} done"
         except subprocess.CalledProcessError as e:
-            return f"ERROR on [{ct}] Chr {chrom}: {e.stderr}"
-    tasks = []
-    for ct in all_cell_types:
-        for chrom in range(1, 23):
-            tasks.append((ct, chrom))
-    max_workers = min(multiprocessing.cpu_count() - 1, 6) 
-    
-    print(f"Starting parallel LDSC calculation with {max_workers} workers...")
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for result in executor.map(calculate_single_chrom, tasks):
-            print(result)
+            return f"ERROR [{ct}] Chr {chrom}: {e.stderr[:200]}"
+
+    tasks = [
+        (ct, chrom, python27_path, HM3_SNP_LIST)
+        for ct in all_cell_types
+        for chrom in range(1, 23)
+        if not os.path.exists(f"data/ldscores/{ct}/{ct}.{chrom}.l2.ldscore.gz")
+    ]
+
+    print(f"{len(tasks)} chromosome-level tasks remaining")
+
+    if tasks:
+        max_workers = min(multiprocessing.cpu_count() - 2, 22)
+        print(f"Running with {max_workers} workers...")
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            for result in executor.map(calculate_single_chrom, tasks):
+                print(result)
 
     print("\nAll LD scores calculated using HapMap3 SNPs")
     return
@@ -555,7 +563,7 @@ def __(subprocess, os, all_cell_types, python27_path):
 
 @app.cell
 def __(mo):
-    mo.md("## 7. Create CTS (cell-type–specific) reference file")
+    mo.md("## 7. Create CTS (cell-type–specific) reference file") 
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -28,12 +28,12 @@ from *Epigenomic dissection of Alzheimer's disease pinpoints causal variants and
 
 All analyses are performed using **GRCh38 / hg38** coordinates.
 """)
-    return
+    return 
 
 
 @app.cell
 def __(mo):
-    GWAS_INPUT_FILE = "data/gwas/atrial_fibrillation.h.tsv.gz"
+    GWAS_INPUT_FILE = "data/gwas/30061737-GCST006414-EFO_0000275.h.tsv.gz"
     gwas_stem = mo.state(GWAS_INPUT_FILE)
     return (GWAS_INPUT_FILE, gwas_stem)
 
@@ -270,7 +270,7 @@ def __(subprocess, os):
 
     nested_files = [
         ("data/reference/GRCh38/baselineLD_v2.2.tgz", "data/reference", "baselineLD_v2.2"),
-        ("data/reference/GRCh38/plink_files.tgz", "data/reference/GRCh38", "plink_files/1000G.EUR.hg38.1.bim"),
+        ("data/reference/GRCh38/plink_files.tgz", "data/reference/GRCh38", "plink_files/1000G.EUR.hg38.1.bim"), 
         ("data/reference/GRCh38/weights.tgz", "data/reference/GRCh38", "weights")
     ]
 
@@ -418,7 +418,7 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
 
         _n_col = next((c for c in _df.columns if c.lower() in ['n', 'n_total', 'sample_size']), None)
         if _n_col:
-            _ldsc['N'] = _df[_n_col]
+            _ldsc['N'] = 1030836
             print(f"Using N from column '{_n_col}' (median: {int(_df[_n_col].median()):,})")
         else:
             print("WARNING: No N column found. Columns available:", list(_df.columns))
@@ -436,7 +436,7 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
         _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
         if _before > len(_ldsc):
             print(f"Removed {_before - len(_ldsc)} duplicate variants")
-
+ 
         print(f"Output: {len(_ldsc)} variants")
         _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
 
@@ -591,7 +591,11 @@ def __(mo):
 
 
 @app.cell
-def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
+def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess, pd):
+    import concurrent.futures as _concurrent_futures
+    import math as _math
+
+    _final_output = f"{RESULTS_PREFIX}.cell_type_results"
 
     if not os.path.exists(SUMSTATS_FILE):
         print(f"Skipping - sumstats file not found: {SUMSTATS_FILE}")
@@ -599,52 +603,55 @@ def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
     elif not os.path.exists(cts_path):
         print(f"Skipping - CTS file not found: {cts_path}")
 
+    elif os.path.exists(_final_output):
+        print(f"Results already exist, skipping: {_final_output}")
+
     else:
         os.makedirs("results", exist_ok=True)
-        print("Running LDSC cell-type–specific heritability analysis...")
 
-        subprocess.run([
-            python27_path, "tools/ldsc/ldsc.py",
-            "--h2-cts",         SUMSTATS_FILE,
-            "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
-            "--ref-ld-chr-cts", cts_path,
-            "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
-            "--out",            RESULTS_PREFIX,
-        ], check=True)
+        with open(cts_path) as _f:
+            _all_lines = _f.readlines()
 
-        print("LDSC CTS analysis completed")
+        _N_BATCHES = 4
+        _batch_size = _math.ceil(len(_all_lines) / _N_BATCHES)
+        _batches = [_all_lines[i:i+_batch_size] for i in range(0, len(_all_lines), _batch_size)]
+
+        _batch_cts_files = []
+        for _i, _batch in enumerate(_batches):
+            _batch_cts = f"{cts_path}.batch{_i}.cts"
+            with open(_batch_cts, "w") as _f:
+                _f.writelines(_batch)
+            _batch_cts_files.append((_i, _batch_cts))
+
+        def _run_batch(args):
+            _i, _batch_cts = args
+            _batch_out = f"{RESULTS_PREFIX}_batch{_i}"
+            print(f"Starting batch {_i} ({len(_batches[_i])} cell types)...")
+            subprocess.run([
+                python27_path, "tools/ldsc/ldsc.py",
+                "--h2-cts",         SUMSTATS_FILE,
+                "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
+                "--ref-ld-chr-cts", _batch_cts,
+                "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
+                "--out",            _batch_out,
+            ], check=True)
+            print(f"Batch {_i} done!")
+            return f"{_batch_out}.cell_type_results"
+
+        print(f"Running {_N_BATCHES} batches in parallel...")
+        with _concurrent_futures.ThreadPoolExecutor(max_workers=_N_BATCHES) as _executor:
+            _result_files = list(_executor.map(_run_batch, _batch_cts_files))
+
+        _dfs = [pd.read_csv(_f, sep="\t") for _f in _result_files if os.path.exists(_f)]
+        _merged = pd.concat(_dfs).sort_values("Coefficient_P_value")
+        _merged.to_csv(_final_output, sep="\t", index=False)
+
+        for _, _batch_cts in _batch_cts_files:
+            os.remove(_batch_cts)
+
+        print(f"Done! {len(_merged)} cell types analyzed.")
 
     return
-@app.cell
-def __(RESULTS_PREFIX, pd, os):
-    results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
-
-    if not os.path.exists(results_file):
-        print(f"Results file not found: {results_file}")
-        ranked = None
-    else:
-        results = pd.read_csv(results_file, sep="\t")
-
-        ranked = results.sort_values("Coefficient_P_value")
-
-        ranked_csv = f"{RESULTS_PREFIX}_ranked_by_pvalue.csv"
-        ranked_txt = f"{RESULTS_PREFIX}_ranked_by_pvalue.txt"
-
-        ranked.to_csv(ranked_csv, index=False)
-        ranked.to_csv(ranked_txt, sep="\t", index=False)
-
-        print("\nTop enriched cell types:\n")
-        print(
-            ranked[
-                ["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value"]
-            ].head(10).to_string(index=False)
-        )
-
-        print(f"\nRanked CSV saved to: {ranked_csv}")
-        print(f"Ranked TXT saved to: {ranked_txt}")
-
-    return (ranked,)
-
 
 if __name__ == "__main__":
     app.run()

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -463,10 +463,6 @@ def _(SSF_FILE, SUMSTATS_FILE, np, os, pd):
         _ldsc = _ldsc[np.isfinite(_ldsc['Z'])]
         _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
         _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
-        print("\n--- Verification for Mentor ---")
-        print(f"Is 'n' column added to raw _df? {'n' in _df.columns}")
-        print(f"Unique N values in original dataset rows: {_df['n'].unique()}")
-        print(f"LDSC conversion complete using calibrated study size: {detected_n}")
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -39,7 +39,7 @@ def __(mo):
 @app.cell
 def __(mo, os):
     GWAS_INPUT_FILE = mo.ui.text(
-        value="data/gwas/PGC_UKB_depression_genome-wide.txt",
+        value="data/gwas/UKBB.GWAS1KG.EXOME.CAD.SOFT.META.PublicRelease.300517.txt.gz",
         label="GWAS input file path",
         full_width=True,
     )
@@ -77,23 +77,18 @@ def __(GWAS_INPUT_FILE, os, re):
             break
     GWAS_STEM      = re.sub(r"[^A-Za-z0-9_\-]", "_", _no_ext)
     GWAS_FILE      = _path
-    PREMUNGE_FILE  = f"data/munging_input/{GWAS_STEM}_premunge.tsv.gz"
     SUMSTATS_FILE  = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
-    MUNGE_PREFIX   = f"data/ldsc_input/{GWAS_STEM}"
     CTS_FILE       = f"data/{GWAS_STEM}_cell_types.cts"
     RESULTS_PREFIX = f"results/{GWAS_STEM}_CellTypeSpecific"
 
     print(f"GWAS stem      : {GWAS_STEM}")
     print(f"GWAS file      : {GWAS_FILE}")
-    print(f"Premunge file  : {PREMUNGE_FILE}")
     print(f"Sumstats file  : {SUMSTATS_FILE}")
     print(f"Results prefix : {RESULTS_PREFIX}")
     return (
         GWAS_STEM,
         GWAS_FILE,
-        PREMUNGE_FILE,
         SUMSTATS_FILE,
-        MUNGE_PREFIX,
         CTS_FILE,
         RESULTS_PREFIX,
     )
@@ -293,160 +288,146 @@ def __(subprocess, os):
 
 @app.cell
 def __(mo):
-    mo.md("## 3. Munge GWAS summary statistics")
+    mo.md("## 3. Setup harmonization workflow")
     return
 
 
 @app.cell
-def __(
-    GWAS_FILE, PREMUNGE_FILE, SUMSTATS_FILE, MUNGE_PREFIX,
-    W_HM3_SNPLIST, python27_path, pd, os, subprocess, glob,
-):
-    import gzip as _gzip
+def __(os, Path):
+    HARMONIZER_CODE_REPO = os.getenv("HARMONIZER_CODE_REPO", "path/to/harmonizer/repo")
+    HARMONIZER_REF_DIR = os.getenv("HARMONIZER_REF_DIR", "path/to/harmonizer/reference")
 
-    os.makedirs("data/ldsc_input", exist_ok=True)
-    os.makedirs("data/munging_input", exist_ok=True)
+    harmonizer_script = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
 
-    if os.path.exists(SUMSTATS_FILE):
-        print(f"Munged sumstats already exists, skipping: {SUMSTATS_FILE}")
+    if not harmonizer_script.exists():
+        print(f"WARNING: harmonizer.sh not found at {harmonizer_script}")
+        print(f"Please set HARMONIZER_CODE_REPO environment variable")
+        harmonizer_ready = False
+    elif not os.path.isdir(HARMONIZER_REF_DIR):
+        print(f"WARNING: Harmonizer reference directory not found at {HARMONIZER_REF_DIR}")
+        print(f"Please run harmonizer_setup.sh first or set HARMONIZER_REF_DIR")
+        harmonizer_ready = False
     else:
-        if not os.path.exists(PREMUNGE_FILE):
-            _lower   = GWAS_FILE.lower()
-            _is_gz   = _lower.endswith(".gz") or _lower.endswith(".bgz")
-            _is_bz2  = _lower.endswith(".bz2")
-            _comp    = "gzip" if _is_gz else ("bz2" if _is_bz2 else None)
-            _open_fn = _gzip.open if _is_gz else open
+        print(f"Harmonizer configuration found")
+        print(f"  Code repo: {HARMONIZER_CODE_REPO}")
+        print(f"  Reference: {HARMONIZER_REF_DIR}")
+        harmonizer_ready = True
 
-            _skip     = 0
-            _peek_line = ""
-            with _open_fn(GWAS_FILE, "rt") as _fh:
-                for _line in _fh:
-                    if _line.startswith("##"):
-                        _skip += 1
-                    else:
-                        _peek_line = _line
-                        break
+    return (HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, harmonizer_ready)
 
-            _sep = "\t" if "\t" in _peek_line else " "
-            print(f"  Separator: {'tab' if _sep == chr(9) else 'space'}")
-
-            _df = pd.read_csv(GWAS_FILE, sep=_sep, compression=_comp, skiprows=_skip)
-            _df.columns = [c.lstrip("#").strip() for c in _df.columns]
-            print(f"  Columns: {list(_df.columns)}")
-
-            _cl = {c.lower(): c for c in _df.columns}
-
-            _rsid_col = (
-                _cl.get("markername") or _cl.get("id") or _cl.get("snp") or
-                _cl.get("rsid") or _cl.get("variant_id") or _cl.get("hm_rsid")
-            )
-            _a1_col = (
-                _cl.get("a1") or _cl.get("alt") or _cl.get("effect_allele") or _cl.get("allele1")
-            )
-            _a2_col = (
-                _cl.get("a2") or _cl.get("ref") or _cl.get("reference") or
-                _cl.get("other_allele") or _cl.get("allele2")
-            )
-            _beta_col = (
-                _cl.get("logor") or _cl.get("log_or") or _cl.get("beta") or
-                _cl.get("b") or _cl.get("hm_beta")
-            )
-            _se_col = (
-                _cl.get("stderrlogor") or _cl.get("se") or _cl.get("stderr") or
-                _cl.get("standard_error") or _cl.get("se_gc")
-            )
-            _p_col = (
-                _cl.get("p") or _cl.get("pval") or _cl.get("pvalue") or
-                _cl.get("p_value") or _cl.get("p-value")
-            )
-            _n_col = (
-                _cl.get("neff") or _cl.get("n_eff") or _cl.get("n") or
-                _cl.get("n_total") or _cl.get("sample_size") or _cl.get("ns")
-            )
-
-            print(f"  Detected — snp:{_rsid_col} a1:{_a1_col} a2:{_a2_col} "
-                  f"beta:{_beta_col} se:{_se_col} p:{_p_col} n:{_n_col}")
-
-            _df = _df.rename(columns={
-                _a1_col: "A1", _a2_col: "A2", _beta_col: "BETA",
-                _se_col: "SE", _p_col: "P", _n_col: "N",
-            })
-
-            if _rsid_col and _df[_rsid_col].astype(str).str.match(r"^rs\d+$", na=False).sum() > 0:
-                print(f"  Using rs IDs from '{_rsid_col}'")
-                _df["SNP"] = _df[_rsid_col]
-            else:
-                print("  Mapping chr:pos -> rsID via bim files...")
-                _bim_map = pd.concat([
-                    pd.read_csv(f, sep="\t", header=None, names=["CHR","SNP","CM","BP","A1b","A2b"])
-                    .assign(key=lambda x: x["CHR"].astype(str) + ":" + x["BP"].astype(str))[["key","SNP"]]
-                    for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
-                ]).drop_duplicates("key").set_index("key")["SNP"]
-                _varid = _cl.get("varid") or _cl.get("variant")
-                if _varid:
-                    _df["key"] = _df[_varid].str.split(":").str[:2].str.join(":")
-                else:
-                    _chr_col = _cl.get("chrom") or _cl.get("chromosome") or _cl.get("chr")
-                    _pos_col = _cl.get("pos") or _cl.get("position") or _cl.get("bp")
-                    if not _chr_col or not _pos_col:
-                        raise ValueError(
-                            f"Cannot find chr/pos columns. Available: {list(_df.columns)}"
-                        )
-                    _df["key"] = (
-                        _df[_chr_col].astype(str).str.replace("chr", "", regex=False)
-                        + ":" + _df[_pos_col].astype(str)
-                    )
-                _before = len(_df)
-                _df["SNP"] = _df["key"].map(_bim_map)
-                _df = _df.drop(columns=["key"])
-                print(f"  Mapped {_df['SNP'].notna().sum():,} / {_before:,} variants to rs IDs")
-
-            if "BETA" in _df.columns:
-                _df["BETA"] = pd.to_numeric(_df["BETA"], errors="coerce")
-            if "SE" in _df.columns:
-                _df["SE"] = pd.to_numeric(_df["SE"], errors="coerce")
-            if "P" in _df.columns:
-                _df["P"] = pd.to_numeric(_df["P"], errors="coerce")
-            if "A1" in _df.columns:
-                _df["A1"] = _df["A1"].str.upper()
-            if "A2" in _df.columns:
-                _df["A2"] = _df["A2"].str.upper()
-
-            _missing = [c for c in ["SNP","A1","A2","BETA","P"] if c not in _df.columns]
-            if _missing:
-                raise ValueError(f"Could not detect required columns: {_missing}. Available: {list(_df.columns)}")
-
-            _keep = [c for c in ["SNP","A1","A2","BETA","SE","P","N"] if c in _df.columns]
-            _out  = _df[_keep].dropna(subset=["SNP","A1","A2","BETA","P"])
-            _out.to_csv(PREMUNGE_FILE, sep="\t", index=False, compression="gzip")
-            print(f"  Written {len(_out):,} variants to {PREMUNGE_FILE}")
-
-        _peek = pd.read_csv(PREMUNGE_FILE, sep="\t", compression="gzip", nrows=2)
-        _munge_cmd = [
-            python27_path, "tools/ldsc/munge_sumstats.py",
-            "--sumstats",        PREMUNGE_FILE,
-            "--out",             MUNGE_PREFIX,
-            "--snp",             "SNP",
-            "--a1",              "A1",
-            "--a2",              "A2",
-            "--signed-sumstats", "BETA,0",
-            "--p",               "P",
-            "--merge-alleles",   W_HM3_SNPLIST,
-        ]
-
-        if "N" in _peek.columns:
-            _munge_cmd += ["--N-col", "N"]
-        else:
-            _munge_cmd += ["--N", "500199"]
-
-        subprocess.run(_munge_cmd, check=True)
-        print(f"Munging complete: {SUMSTATS_FILE}")
-
-    return
 
 @app.cell
 def __(mo):
-    mo.md("## 4. Generate cell-type-specific binary annotations (BED -> .annot.gz)") 
+    mo.md("## 4. Harmonize GWAS summary statistics")
+    return
+
+
+@app.cell
+def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, GWAS_FILE):
+    os.makedirs("data/harmonized", exist_ok=True)
+
+    harmonized_found = False
+    if os.path.exists("data/harmonized"):
+        for item in os.listdir("data/harmonized"):
+            if os.path.isdir(os.path.join("data/harmonized", item)):
+                _final_dir = os.path.join("data/harmonized", item, "final")
+                if os.path.exists(_final_dir):
+                    harmonized_found = True
+                    harmonized_output_dir = os.path.join("data/harmonized", item)
+                    break
+
+    if harmonized_found:
+        print(f"Harmonized GWAS file already exists: {harmonized_output_dir}")
+    elif not harmonizer_ready:
+        print("Skipping harmonization - harmonizer not configured")
+        harmonized_output_dir = None
+    else:
+        os.chdir("data/harmonized")
+
+        try:
+            _result = subprocess.run([
+                "bash",
+                os.path.join(HARMONIZER_CODE_REPO, "harmonizer.sh"),
+                "--input", os.path.abspath(GWAS_FILE),
+                "--build", "GRCh38",
+                "--ref", HARMONIZER_REF_DIR,
+                "--code-repo", HARMONIZER_CODE_REPO,
+                "--threshold", "0.99"
+            ], check=True, capture_output=True, text=True)
+
+            print(_result.stdout)
+            if _result.stderr:
+                print("STDERR:", _result.stderr)
+
+            harmonized_dirs = [d for d in os.listdir(".") if os.path.isdir(d)]
+            if harmonized_dirs:
+                harmonized_output_dir = os.path.abspath(max(harmonized_dirs))
+                print(f"Harmonization complete: {harmonized_output_dir}")
+            else:
+                print("WARNING: No output directory found after harmonization")
+                harmonized_output_dir = None
+
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: Harmonization failed")
+            print(f"STDOUT: {e.stdout}")
+            print(f"STDERR: {e.stderr}")
+            harmonized_output_dir = None
+        finally:
+            os.chdir("../..")
+
+    return (harmonized_output_dir,)
+
+
+@app.cell
+def __(mo):
+    mo.md("## 5. Convert harmonized output to LDSC format")
+    return
+
+
+@app.cell
+def __(os, subprocess, python27_path, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
+    os.makedirs("data/ldsc_input", exist_ok=True)
+
+    if harmonized_output_dir is None:
+        print("Skipping LDSC conversion - no harmonized data available")
+    elif os.path.exists(SUMSTATS_FILE):
+        print(f"LDSC sumstats already exists, skipping: {SUMSTATS_FILE}")
+    else:
+        _final_dir = os.path.join(harmonized_output_dir, "final")
+
+        if not os.path.exists(_final_dir):
+            print(f"WARNING: Final directory not found: {_final_dir}")
+        else:
+            _harmonized_files = [f for f in os.listdir(_final_dir) if f.endswith(".tsv.gz")]
+
+            if not _harmonized_files:
+                print(f"WARNING: No .tsv.gz file found in {_final_dir}")
+            else:
+                _harmonized_file = os.path.join(_final_dir, _harmonized_files[0])
+                print(f"Found harmonized file: {_harmonized_file}")
+
+                _munge_prefix = SUMSTATS_FILE.replace(".sumstats.gz", "")
+
+                subprocess.run([
+                    python27_path, "tools/ldsc/munge_sumstats.py",
+                    "--sumstats",        _harmonized_file,
+                    "--out",             _munge_prefix,
+                    "--a1",              "effect_allele",
+                    "--a2",              "other_allele",
+                    "--p",               "p_value",
+                    "--snp",             "rsid",
+                    "--signed-sumstats", "beta,0",
+                    "--merge-alleles",   W_HM3_SNPLIST,
+                ], check=True)
+
+                print(f"LDSC conversion complete: {SUMSTATS_FILE}")
+
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("## 6. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
     return
 
 
@@ -492,7 +473,7 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
 
 @app.cell
 def __(mo):
-    mo.md("## 5. Calculate LD scores (HapMap3 SNPs only)")
+    mo.md("## 7. Calculate LD scores (HapMap3 SNPs only)")
     return
 
 
@@ -539,12 +520,12 @@ def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessin
 
 @app.cell
 def __(mo):
-    mo.md("## 6. Create CTS reference file")
+    mo.md("## 8. Create CTS reference file")
     return
 
 
 @app.cell
-def __(os, all_cell_types, GWAS_STEM, CTS_FILE):
+def __(os, all_cell_types, CTS_FILE):
     os.makedirs("results", exist_ok=True)
 
     COMPLETED_CELL_TYPES = []
@@ -570,7 +551,7 @@ def __(os, all_cell_types, GWAS_STEM, CTS_FILE):
 
 @app.cell
 def __(mo):
-    mo.md("## 7. Run LDSC cell-type-specific heritability analysis")
+    mo.md("## 9. Run LDSC cell-type-specific heritability analysis")
     return
 
 
@@ -603,7 +584,7 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
 @app.cell
 def __(mo):
-    mo.md("## 8. Results")
+    mo.md("## 10. Results")
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -39,7 +39,7 @@ def __(mo):
 @app.cell
 def __(mo, os):
     GWAS_INPUT_FILE = mo.ui.text(
-        value="data/gwas/mdd_symptoms_2023-Clin-MDD1_depressed.txt.gz",
+        value="data/gwas/PGC_UKB_depression_genome-wide.txt",
         label="GWAS input file path",
         full_width=True,
     )
@@ -311,27 +311,61 @@ def __(
         print(f"Munged sumstats already exists, skipping: {SUMSTATS_FILE}")
     else:
         if not os.path.exists(PREMUNGE_FILE):
-            _skip = 0
-            with _gzip.open(GWAS_FILE, "rt") as _fh:
+            _lower   = GWAS_FILE.lower()
+            _is_gz   = _lower.endswith(".gz") or _lower.endswith(".bgz")
+            _is_bz2  = _lower.endswith(".bz2")
+            _comp    = "gzip" if _is_gz else ("bz2" if _is_bz2 else None)
+            _open_fn = _gzip.open if _is_gz else open
+
+            _skip     = 0
+            _peek_line = ""
+            with _open_fn(GWAS_FILE, "rt") as _fh:
                 for _line in _fh:
                     if _line.startswith("##"):
                         _skip += 1
                     else:
+                        _peek_line = _line
                         break
 
-            _df = pd.read_csv(GWAS_FILE, sep="\t", compression="gzip", skiprows=_skip)
+            _sep = "\t" if "\t" in _peek_line else " "
+            print(f"  Separator: {'tab' if _sep == chr(9) else 'space'}")
+
+            _df = pd.read_csv(GWAS_FILE, sep=_sep, compression=_comp, skiprows=_skip)
             _df.columns = [c.lstrip("#").strip() for c in _df.columns]
             print(f"  Columns: {list(_df.columns)}")
 
             _cl = {c.lower(): c for c in _df.columns}
 
-            _rsid_col  = _cl.get("id") or _cl.get("snp") or _cl.get("rsid") or _cl.get("variant_id")
-            _a1_col    = _cl.get("a1") or _cl.get("alt") or _cl.get("effect_allele")
-            _a2_col    = _cl.get("a2") or _cl.get("ref") or _cl.get("reference") or _cl.get("other_allele")
-            _beta_col  = _cl.get("beta") or _cl.get("b") or _cl.get("logor")
-            _se_col    = _cl.get("se") or _cl.get("stderr") or _cl.get("standard_error")
-            _p_col     = _cl.get("pval") or _cl.get("pvalue") or _cl.get("p_value") or _cl.get("p")
-            _n_col     = _cl.get("neff") or _cl.get("n") or _cl.get("n_total") or _cl.get("sample_size")
+            _rsid_col = (
+                _cl.get("markername") or _cl.get("id") or _cl.get("snp") or
+                _cl.get("rsid") or _cl.get("variant_id") or _cl.get("hm_rsid")
+            )
+            _a1_col = (
+                _cl.get("a1") or _cl.get("alt") or _cl.get("effect_allele") or _cl.get("allele1")
+            )
+            _a2_col = (
+                _cl.get("a2") or _cl.get("ref") or _cl.get("reference") or
+                _cl.get("other_allele") or _cl.get("allele2")
+            )
+            _beta_col = (
+                _cl.get("logor") or _cl.get("log_or") or _cl.get("beta") or
+                _cl.get("b") or _cl.get("hm_beta")
+            )
+            _se_col = (
+                _cl.get("stderrlogor") or _cl.get("se") or _cl.get("stderr") or
+                _cl.get("standard_error") or _cl.get("se_gc")
+            )
+            _p_col = (
+                _cl.get("p") or _cl.get("pval") or _cl.get("pvalue") or
+                _cl.get("p_value") or _cl.get("p-value")
+            )
+            _n_col = (
+                _cl.get("neff") or _cl.get("n_eff") or _cl.get("n") or
+                _cl.get("n_total") or _cl.get("sample_size") or _cl.get("ns")
+            )
+
+            print(f"  Detected — snp:{_rsid_col} a1:{_a1_col} a2:{_a2_col} "
+                  f"beta:{_beta_col} se:{_se_col} p:{_p_col} n:{_n_col}")
 
             _df = _df.rename(columns={
                 _a1_col: "A1", _a2_col: "A2", _beta_col: "BETA",
@@ -339,29 +373,56 @@ def __(
             })
 
             if _rsid_col and _df[_rsid_col].astype(str).str.match(r"^rs\d+$", na=False).sum() > 0:
+                print(f"  Using rs IDs from '{_rsid_col}'")
                 _df["SNP"] = _df[_rsid_col]
             else:
+                print("  Mapping chr:pos -> rsID via bim files...")
                 _bim_map = pd.concat([
                     pd.read_csv(f, sep="\t", header=None, names=["CHR","SNP","CM","BP","A1b","A2b"])
                     .assign(key=lambda x: x["CHR"].astype(str) + ":" + x["BP"].astype(str))[["key","SNP"]]
                     for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
                 ]).drop_duplicates("key").set_index("key")["SNP"]
                 _varid = _cl.get("varid") or _cl.get("variant")
-                _df["key"] = _df[_varid].str.split(":").str[:2].str.join(":") if _varid else (
-                    _df[_cl.get("chrom") or _cl.get("chr")].astype(str).str.replace("chr","",regex=False)
-                    + ":" + _df[_cl.get("pos") or _cl.get("position")].astype(str)
-                )
+                if _varid:
+                    _df["key"] = _df[_varid].str.split(":").str[:2].str.join(":")
+                else:
+                    _chr_col = _cl.get("chrom") or _cl.get("chromosome") or _cl.get("chr")
+                    _pos_col = _cl.get("pos") or _cl.get("position") or _cl.get("bp")
+                    if not _chr_col or not _pos_col:
+                        raise ValueError(
+                            f"Cannot find chr/pos columns. Available: {list(_df.columns)}"
+                        )
+                    _df["key"] = (
+                        _df[_chr_col].astype(str).str.replace("chr", "", regex=False)
+                        + ":" + _df[_pos_col].astype(str)
+                    )
+                _before = len(_df)
                 _df["SNP"] = _df["key"].map(_bim_map)
                 _df = _df.drop(columns=["key"])
+                print(f"  Mapped {_df['SNP'].notna().sum():,} / {_before:,} variants to rs IDs")
+
+            if "BETA" in _df.columns:
+                _df["BETA"] = pd.to_numeric(_df["BETA"], errors="coerce")
+            if "SE" in _df.columns:
+                _df["SE"] = pd.to_numeric(_df["SE"], errors="coerce")
+            if "P" in _df.columns:
+                _df["P"] = pd.to_numeric(_df["P"], errors="coerce")
+            if "A1" in _df.columns:
+                _df["A1"] = _df["A1"].str.upper()
+            if "A2" in _df.columns:
+                _df["A2"] = _df["A2"].str.upper()
+
+            _missing = [c for c in ["SNP","A1","A2","BETA","P"] if c not in _df.columns]
+            if _missing:
+                raise ValueError(f"Could not detect required columns: {_missing}. Available: {list(_df.columns)}")
 
             _keep = [c for c in ["SNP","A1","A2","BETA","SE","P","N"] if c in _df.columns]
-            _df[_keep].dropna(subset=["SNP","A1","A2","BETA","P"]).to_csv(
-                PREMUNGE_FILE, sep="\t", index=False, compression="gzip"
-            )
-            print(f"  Written {len(_df):,} variants to {PREMUNGE_FILE}")
+            _out  = _df[_keep].dropna(subset=["SNP","A1","A2","BETA","P"])
+            _out.to_csv(PREMUNGE_FILE, sep="\t", index=False, compression="gzip")
+            print(f"  Written {len(_out):,} variants to {PREMUNGE_FILE}")
 
         _peek = pd.read_csv(PREMUNGE_FILE, sep="\t", compression="gzip", nrows=2)
-        subprocess.run([
+        _munge_cmd = [
             python27_path, "tools/ldsc/munge_sumstats.py",
             "--sumstats",        PREMUNGE_FILE,
             "--out",             MUNGE_PREFIX,
@@ -371,15 +432,21 @@ def __(
             "--signed-sumstats", "BETA,0",
             "--p",               "P",
             "--merge-alleles",   W_HM3_SNPLIST,
-        ] + (["--N-col", "N"] if "N" in _peek.columns else []), check=True)
+        ]
+
+        if "N" in _peek.columns:
+            _munge_cmd += ["--N-col", "N"]
+        else:
+            _munge_cmd += ["--N", "500199"]
+
+        subprocess.run(_munge_cmd, check=True)
         print(f"Munging complete: {SUMSTATS_FILE}")
 
     return
 
-
 @app.cell
 def __(mo):
-    mo.md("## 4. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
+    mo.md("## 4. Generate cell-type-specific binary annotations (BED -> .annot.gz)") 
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -270,7 +270,7 @@ def __(subprocess, os):
 
     nested_files = [
         ("data/reference/GRCh38/baselineLD_v2.2.tgz", "data/reference", "baselineLD_v2.2"),
-        ("data/reference/GRCh38/plink_files.tgz", "data/reference/GRCh38", "plink_files/1000G.EUR.hg38.1.bim"), 
+        ("data/reference/GRCh38/plink_files.tgz", "data/reference/GRCh38", "plink_files/1000G.EUR.hg38.1.bim"),
         ("data/reference/GRCh38/weights.tgz", "data/reference/GRCh38", "weights")
     ]
 
@@ -306,36 +306,43 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
         print(f"Converting {GWAS_INPUT_FILE} -> {SSF_FILE}")
 
         _df = pd.read_csv(GWAS_INPUT_FILE, sep="\t", compression="gzip")
-        _cols_lower = {col.lower(): col for col in _df.columns}
-        _col_map = {}
 
-        if "variant" in _cols_lower:
-            print("Detected Neale format")
-            _df[['chromosome', 'base_pair_location', 'other_allele', 'effect_allele']] = \
-                _df[_cols_lower['variant']].str.split(':', expand=True)
+        _has_hm = any(c.startswith("hm_") for c in _df.columns)
+
+        if _has_hm:
+            print("Detected GWAS Catalog harmonised format (hm_ columns)")
+            _df2 = pd.DataFrame()
+            _df2['chromosome']            = _df['hm_chrom'].astype(str)
+            _df2['base_pair_location']    = pd.to_numeric(_df['hm_pos'], errors='coerce')
+            _df2['effect_allele']         = _df['hm_effect_allele'].str.upper()
+            _df2['other_allele']          = _df['hm_other_allele'].str.upper()
+            _df2['beta']                  = pd.to_numeric(_df['hm_beta'], errors='coerce')
+            _df2['standard_error']        = pd.to_numeric(_df['standard_error'], errors='coerce')
+            _df2['p_value']               = pd.to_numeric(_df['p_value'], errors='coerce')
+            _df2['effect_allele_frequency'] = pd.to_numeric(_df['hm_effect_allele_frequency'], errors='coerce').fillna('NA')
+            _df2['rsid']                  = _df['hm_rsid'].fillna('NA')
+            _df = _df2
         else:
-            print("Detected PLINK/standard format")
-            _col_map['chromosome'] = _cols_lower.get('chr') or _cols_lower.get('chrom') or _cols_lower.get('chromosome')
-            _col_map['base_pair_location'] = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
-            _col_map['effect_allele'] = _cols_lower.get('a1') or _cols_lower.get('effect_allele')
-            _col_map['other_allele'] = _cols_lower.get('a2') or _cols_lower.get('other_allele')
-
-        _col_map['beta'] = _cols_lower.get('beta')
-        _col_map['standard_error'] = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error')
-        _col_map['p_value'] = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value')
-        _col_map['effect_allele_frequency'] = (
-            _cols_lower.get('a1_freq') or _cols_lower.get('frq') or
-            _cols_lower.get('af') or _cols_lower.get('effect_allele_frequency')
-        )
-        _col_map['rsid'] = (
-            _cols_lower.get('id') or _cols_lower.get('snp') or
-            _cols_lower.get('rsid') or _cols_lower.get('variant_id')
-        )
-        _col_map['n_total'] = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
-
-        if "variant" not in _cols_lower:
-            _rename_map = {v: k for k, v in _col_map.items() if v is not None}
-            _df = _df.rename(columns=_rename_map)
+            _cols_lower = {col.lower(): col for col in _df.columns}
+            if "variant" in _cols_lower:
+                print("Detected Neale format")
+                _df[['chromosome', 'base_pair_location', 'other_allele', 'effect_allele']] = \
+                    _df[_cols_lower['variant']].str.split(':', expand=True)
+            else:
+                print("Detected PLINK/standard format")
+                _col_map = {}
+                _col_map['chromosome']          = _cols_lower.get('chr') or _cols_lower.get('chrom') or _cols_lower.get('chromosome')
+                _col_map['base_pair_location']  = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
+                _col_map['effect_allele']       = _cols_lower.get('a1') or _cols_lower.get('effect_allele')
+                _col_map['other_allele']        = _cols_lower.get('a2') or _cols_lower.get('other_allele')
+                _col_map['beta']                = _cols_lower.get('beta')
+                _col_map['standard_error']      = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error')
+                _col_map['p_value']             = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value')
+                _col_map['effect_allele_frequency'] = _cols_lower.get('a1_freq') or _cols_lower.get('frq') or _cols_lower.get('af') or _cols_lower.get('effect_allele_frequency')
+                _col_map['rsid']                = _cols_lower.get('id') or _cols_lower.get('snp') or _cols_lower.get('rsid') or _cols_lower.get('variant_id')
+                _col_map['n_total']             = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
+                _rename_map = {v: k for k, v in _col_map.items() if v is not None}
+                _df = _df.rename(columns=_rename_map)
 
         _df['chromosome'] = _df['chromosome'].astype(str).str.replace('chr', '', regex=False)
         _df['chromosome'] = _df['chromosome'].replace({'23': 'X', '24': 'Y', '26': 'MT'})
@@ -344,18 +351,12 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
         _df = _df[~_df['chromosome'].isin(['X', 'Y', 'MT'])]
         print(f"  Removed {_before - len(_df)} variants on sex/MT chromosomes")
 
-        _df['base_pair_location'] = pd.to_numeric(_df['base_pair_location'], errors='coerce')
-        _df['effect_allele'] = _df['effect_allele'].str.upper()
-        _df['other_allele'] = _df['other_allele'].str.upper()
-        _df['effect_allele_frequency'] = _df['effect_allele_frequency'].fillna('NA') if 'effect_allele_frequency' in _df.columns else 'NA'
-        _df['rsid'] = _df['rsid'].fillna('NA') if 'rsid' in _df.columns else 'NA'
-
         _ssf_cols = ['chromosome', 'base_pair_location', 'effect_allele', 'other_allele',
                      'beta', 'standard_error', 'p_value', 'effect_allele_frequency', 'rsid']
         if 'n_total' in _df.columns:
             _ssf_cols.append('n_total')
 
-        _df_ssf = _df[_ssf_cols]
+        _df_ssf = _df[[c for c in _ssf_cols if c in _df.columns]]
         _df_ssf.to_csv(SSF_FILE, sep="\t", index=False, compression="gzip")
 
         subprocess.run(
@@ -374,7 +375,7 @@ coordinate_system: 1-based
 data_file_name: {os.path.basename(SSF_FILE)}
 file_type: GWAS-SSF v0.1
 data_file_md5sum: {_md5}
-is_harmonised: false
+is_harmonised: true
 is_sorted: false
 """)
         print("SSF conversion complete")
@@ -414,18 +415,12 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
 
         _ldsc['A1'] = _df['effect_allele'].str.upper()
         _ldsc['A2'] = _df['other_allele'].str.upper()
-        _ldsc['Z'] = _df['beta'] / _df['standard_error']
-
-        _n_col = next((c for c in _df.columns if c.lower() in ['n', 'n_total', 'sample_size']), None)
-        if _n_col:
-            _ldsc['N'] = 1030836
-            print(f"Using N from column '{_n_col}' (median: {int(_df[_n_col].median()):,})")
-        else:
-            print("WARNING: No N column found. Columns available:", list(_df.columns))
-            _ldsc['N'] = np.nan
+        _ldsc['Z']  = pd.to_numeric(_df['beta'], errors='coerce') / pd.to_numeric(_df['standard_error'], errors='coerce')
+        _ldsc['N']  = 1030836
+        print("Using hardcoded N = 1,030,836 (Nielsen et al. 2018 AF GWAS)")
 
         if 'p_value' in _df.columns:
-            _ldsc['P'] = _df['p_value']
+            _ldsc['P'] = pd.to_numeric(_df['p_value'], errors='coerce')
 
         _before = len(_ldsc)
         _ldsc = _ldsc[np.isfinite(_ldsc['Z'])]
@@ -436,7 +431,7 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
         _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
         if _before > len(_ldsc):
             print(f"Removed {_before - len(_ldsc)} duplicate variants")
- 
+
         print(f"Output: {len(_ldsc)} variants")
         _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
 
@@ -513,11 +508,12 @@ def __(subprocess, os, all_cell_types, python27_path):
 
     os.makedirs("data/ldscores", exist_ok=True)
     HM3_SNP_LIST = "data/reference/hm3_no_MHC.list.txt"
+
     def calculate_single_chrom(args):
         ct, chrom = args
         out_dir = f"data/ldscores/{ct}"
         os.makedirs(out_dir, exist_ok=True)
-        
+
         ldscore_file = f"{out_dir}/{ct}.{chrom}.l2.ldscore.gz"
         if os.path.exists(ldscore_file):
             return f"[{ct}] Chr {chrom} already exists. Skipping."
@@ -534,14 +530,15 @@ def __(subprocess, os, all_cell_types, python27_path):
                 "--out",        f"{out_dir}/{ct}.{chrom}"
             ], check=True, capture_output=True)
             return f"[{ct}] Chr {chrom} calculation complete."
-        except subprocess.CalledProcessError as e: 
+        except subprocess.CalledProcessError as e:
             return f"ERROR on [{ct}] Chr {chrom}: {e.stderr}"
+
     tasks = []
     for ct in all_cell_types:
         for chrom in range(1, 23):
             tasks.append((ct, chrom))
     max_workers = min(multiprocessing.cpu_count() - 1, 6)
-    
+
     print(f"Starting parallel LDSC calculation with {max_workers} workers...")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         for result in executor.map(calculate_single_chrom, tasks):
@@ -549,7 +546,6 @@ def __(subprocess, os, all_cell_types, python27_path):
 
     print("\nAll LD scores calculated using HapMap3 SNPs")
     return
-
 
 
 @app.cell
@@ -591,9 +587,7 @@ def __(mo):
 
 
 @app.cell
-def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess, pd):
-    import concurrent.futures as _concurrent_futures
-    import math as _math
+def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
     _final_output = f"{RESULTS_PREFIX}.cell_type_results"
 
@@ -608,50 +602,51 @@ def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess, p
 
     else:
         os.makedirs("results", exist_ok=True)
+        print("Running LDSC cell-type–specific heritability analysis...")
 
-        with open(cts_path) as _f:
-            _all_lines = _f.readlines()
+        subprocess.run([
+            python27_path, "tools/ldsc/ldsc.py",
+            "--h2-cts",         SUMSTATS_FILE,
+            "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
+            "--ref-ld-chr-cts", cts_path,
+            "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
+            "--out",            RESULTS_PREFIX,
+        ], check=True)
 
-        _N_BATCHES = 4
-        _batch_size = _math.ceil(len(_all_lines) / _N_BATCHES)
-        _batches = [_all_lines[i:i+_batch_size] for i in range(0, len(_all_lines), _batch_size)]
-
-        _batch_cts_files = []
-        for _i, _batch in enumerate(_batches):
-            _batch_cts = f"{cts_path}.batch{_i}.cts"
-            with open(_batch_cts, "w") as _f:
-                _f.writelines(_batch)
-            _batch_cts_files.append((_i, _batch_cts))
-
-        def _run_batch(args):
-            _i, _batch_cts = args
-            _batch_out = f"{RESULTS_PREFIX}_batch{_i}"
-            print(f"Starting batch {_i} ({len(_batches[_i])} cell types)...")
-            subprocess.run([
-                python27_path, "tools/ldsc/ldsc.py",
-                "--h2-cts",         SUMSTATS_FILE,
-                "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
-                "--ref-ld-chr-cts", _batch_cts,
-                "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
-                "--out",            _batch_out,
-            ], check=True)
-            print(f"Batch {_i} done!")
-            return f"{_batch_out}.cell_type_results"
-
-        print(f"Running {_N_BATCHES} batches in parallel...")
-        with _concurrent_futures.ThreadPoolExecutor(max_workers=_N_BATCHES) as _executor:
-            _result_files = list(_executor.map(_run_batch, _batch_cts_files))
-
-        _dfs = [pd.read_csv(_f, sep="\t") for _f in _result_files if os.path.exists(_f)]
-        _merged = pd.concat(_dfs).sort_values("Coefficient_P_value")
-        _merged.to_csv(_final_output, sep="\t", index=False)
-
-        for _, _batch_cts in _batch_cts_files:
-            os.remove(_batch_cts)
-
-        print(f"Done! {len(_merged)} cell types analyzed.")
+        print("LDSC CTS analysis completed")
 
     return
+
+
+@app.cell
+def __(RESULTS_PREFIX, pd, os):
+    results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
+
+    if not os.path.exists(results_file):
+        print(f"Results file not found: {results_file}")
+        ranked = None
+    else:
+        results = pd.read_csv(results_file, sep="\t")
+
+        ranked = results.sort_values("Coefficient_P_value")
+
+        ranked_csv = f"{RESULTS_PREFIX}_ranked_by_pvalue.csv"
+        ranked_txt = f"{RESULTS_PREFIX}_ranked_by_pvalue.txt"
+
+        ranked.to_csv(ranked_csv, index=False)
+        ranked.to_csv(ranked_txt, sep="\t", index=False)
+
+        print("\nTop enriched cell types:\n")
+        print(
+            ranked[
+                ["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value"]
+            ].head(10).to_string(index=False)
+        )
+
+        print(f"\nRanked CSV saved to: {ranked_csv}")
+        print(f"Ranked TXT saved to: {ranked_txt}")
+    return (ranked,)
+
 
 if __name__ == "__main__":
     app.run()

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -33,18 +33,18 @@ All analyses are performed using **GRCh38 / hg38** coordinates.
 
 @app.cell
 def __(mo):
-    GWAS_INPUT_FILE = "data/gwas/30061737-GCST006414-EFO_0000275.h.tsv.gz"
+    GWAS_INPUT_FILE = "data/gwas/28714975-GCST004787-EFO_0001645.h.tsv.gz.2"
     gwas_stem = mo.state(GWAS_INPUT_FILE)
     return (GWAS_INPUT_FILE, gwas_stem)
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, os):
+def __(GWAS_INPUT_FILE, os): 
     import re as _re
 
     _basename = os.path.basename(GWAS_INPUT_FILE)
     _no_ext = _basename
-    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv"]:
+    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv"]: 
         if _no_ext.endswith(_ext):
             _no_ext = _no_ext[: -len(_ext)]
             break
@@ -297,7 +297,7 @@ def __(mo):
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, datetime):
+def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, datetime): 
     os.makedirs("data/ssf", exist_ok=True)
 
     if os.path.exists(SSF_FILE):
@@ -307,7 +307,7 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
 
         _df = pd.read_csv(GWAS_INPUT_FILE, sep="\t", compression="gzip")
 
-        _has_hm = any(c.startswith("hm_") for c in _df.columns)
+        _has_hm = any(c.startswith("hm_") for c in _df.columns) and _df['hm_chrom'].notna().any()
 
         if _has_hm:
             print("Detected GWAS Catalog harmonised format (hm_ columns)")
@@ -335,12 +335,12 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
                 _col_map['base_pair_location']  = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
                 _col_map['effect_allele']       = _cols_lower.get('a1') or _cols_lower.get('effect_allele')
                 _col_map['other_allele']        = _cols_lower.get('a2') or _cols_lower.get('other_allele')
-                _col_map['beta']                = _cols_lower.get('beta')
+                _col_map['beta'] = _cols_lower.get('beta') or _cols_lower.get('logor')
+                _col_map['n_total'] = _cols_lower.get('n_samples') or _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
                 _col_map['standard_error']      = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error')
                 _col_map['p_value']             = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value')
                 _col_map['effect_allele_frequency'] = _cols_lower.get('a1_freq') or _cols_lower.get('frq') or _cols_lower.get('af') or _cols_lower.get('effect_allele_frequency')
                 _col_map['rsid']                = _cols_lower.get('id') or _cols_lower.get('snp') or _cols_lower.get('rsid') or _cols_lower.get('variant_id')
-                _col_map['n_total']             = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
                 _rename_map = {v: k for k, v in _col_map.items() if v is not None}
                 _df = _df.rename(columns=_rename_map)
 
@@ -388,7 +388,7 @@ def __(mo):
     mo.md("## 4. Convert SSF to LDSC format")
     return
 
-
+#TODO: Extract "N" directly from the metadata
 @app.cell
 def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
     os.makedirs("data/ldsc_input", exist_ok=True)
@@ -396,12 +396,12 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
     if os.path.exists(SUMSTATS_FILE):
         print(f"LDSC sumstats file already exists: {SUMSTATS_FILE}")
     else:
-        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}")
+        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}") 
 
         _df = pd.read_csv(SSF_FILE, sep='\t', compression='gzip')
         print(f"Input: {len(_df)} variants")
 
-        _ldsc = pd.DataFrame()
+        _ldsc = pd.DataFrame() 
 
         if 'rsid' in _df.columns and (_df['rsid'] != 'NA').any():
             _ldsc['SNP'] = _df['rsid']
@@ -416,8 +416,8 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
         _ldsc['A1'] = _df['effect_allele'].str.upper()
         _ldsc['A2'] = _df['other_allele'].str.upper()
         _ldsc['Z']  = pd.to_numeric(_df['beta'], errors='coerce') / pd.to_numeric(_df['standard_error'], errors='coerce')
-        _ldsc['N']  = 1030836
-        print("Using hardcoded N = 1,030,836 (Nielsen et al. 2018 AF GWAS)")
+        _ldsc['N']  = 63731
+        print("Using hardcoded N (Nielsen et al. 2018 AF GWAS)")
 
         if 'p_value' in _df.columns:
             _ldsc['P'] = pd.to_numeric(_df['p_value'], errors='coerce')

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
+
 import marimo
 
-__generated_with = "0.9.14"
+__generated_with = "0.23.1"
 app = marimo.App(width="medium")
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     import urllib.request
     import os
@@ -19,11 +20,25 @@ def __():
     import glob
     import concurrent.futures
     import multiprocessing
-    return mo, urllib, os, re, subprocess, pd, np, Path, json, glob, concurrent, multiprocessing
+
+    return (
+        Path,
+        concurrent,
+        glob,
+        json,
+        mo,
+        multiprocessing,
+        np,
+        os,
+        pd,
+        re,
+        subprocess,
+        urllib,
+    )
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md("""
     This notebook reproduces the LDSC cell-type-specific heritability analysis
     from *A single-cell atlas of chromatin accessibility in the human genome* (Zhang et al. 2021).
@@ -37,7 +52,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo, os):
+def _(mo):
     GWAS_INPUT_FILE = mo.ui.text(
         value="data/gwas/PASS_AtrialFibrillation_Nielsen2018.sumstats.gz",
         label="GWAS input file path",
@@ -47,23 +62,23 @@ def __(mo, os):
     HM3_NO_MHC_LIST = "data/reference/hm3_no_MHC.list.txt"
     CATLAS_DIR       = "humanenhancer_atac_data"
     CATLAS_URL       = "http://catlas.org/humanenhancer/data/cCREs/"
-  
+
     mo.vstack([
         mo.md("### Configuration"),
         GWAS_INPUT_FILE,
         mo.md(f"w_hm3.snplist: `{W_HM3_SNPLIST}`"),
     ])
     return (
-        GWAS_INPUT_FILE,
-        W_HM3_SNPLIST,
-        HM3_NO_MHC_LIST,
         CATLAS_DIR,
-        CATLAS_URL
+        CATLAS_URL,
+        GWAS_INPUT_FILE,
+        HM3_NO_MHC_LIST,
+        W_HM3_SNPLIST,
     )
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, os, re):
+def _(GWAS_INPUT_FILE, os, re):
     _path = GWAS_INPUT_FILE.value
     _basename = os.path.basename(_path)
     _no_ext = _basename
@@ -81,23 +96,19 @@ def __(GWAS_INPUT_FILE, os, re):
     print(f"GWAS file      : {GWAS_FILE}")
     print(f"Sumstats file  : {SUMSTATS_FILE}")
     print(f"Results prefix : {RESULTS_PREFIX}")
-    return (
-        GWAS_STEM,
-        GWAS_FILE,
-        SUMSTATS_FILE,
-        CTS_FILE,
-        RESULTS_PREFIX,
-    )
+    return CTS_FILE, GWAS_FILE, RESULTS_PREFIX, SUMSTATS_FILE
 
 
 @app.cell
-def __(mo):
-    mo.md("## 0. Setup: download and configure LDSC")
+def _(mo):
+    mo.md("""
+    ## 0. Setup: download and configure LDSC
+    """)
     return
 
 
 @app.cell
-def __(Path, subprocess, os, json):
+def _(Path, json, os, subprocess):
     TOOLS_DIR = Path("tools")
     LDSC_DIR  = TOOLS_DIR / "ldsc"
     TOOLS_DIR.mkdir(exist_ok=True)
@@ -150,21 +161,19 @@ def __(Path, subprocess, os, json):
     print(f"LDSC environment ready")
     print(f"Python 2.7 : {python27_path}")
     print(f"LDSC dir   : {LDSC_DIR}")
-    return (TOOLS_DIR, LDSC_DIR, ldsc27_path, python27_path)
+    return ldsc27_path, python27_path
 
 
 @app.cell
-def __(mo):
-    mo.md("## 1. Discover cell types and resolve BED sources")
+def _(mo):
+    mo.md("""
+    ## 1. Discover cell types and resolve BED sources
+    """)
     return
 
 
 @app.cell
-def __(
-    os, urllib, pd, subprocess, re,
-    CATLAS_DIR, CATLAS_URL,
-    GWAS_FILE,
-):
+def _(CATLAS_DIR, CATLAS_URL, os, pd, re, subprocess, urllib):
     for _d in ["data/peaks", "data/reference", "data/gwas", "data/beds"]:
         os.makedirs(_d, exist_ok=True)
 
@@ -199,7 +208,7 @@ def __(
         bed_out  = f"data/beds/{ct}.bed"
         if os.path.exists(bed_out):
             return bed_out
-        
+
         _peaks = pd.read_csv(peak_txt, sep="\t")
         _peaks[["seqnames", "start", "end"]].rename(
             columns={"seqnames": "chr"}
@@ -214,7 +223,7 @@ def __(
             for _f in os.listdir(_sd):
                 if _f.endswith(".bed") and not _f.startswith("."):
                     raw_names.add(os.path.splitext(_f)[0])
-  
+
 
     cell_type_beds = {}
     _seen = {}
@@ -244,17 +253,19 @@ def __(
             urllib.request.urlretrieve(_url, _dst)
 
     print("All sources resolved")
-    return (all_cell_types, cell_type_beds, BED_SEARCH_DIRS)
+    return all_cell_types, cell_type_beds
 
 
 @app.cell
-def __(mo):
-    mo.md("## 2. Extract reference LD panels")
+def _(mo):
+    mo.md("""
+    ## 2. Extract reference LD panels
+    """)
     return
 
 
 @app.cell
-def __(subprocess, os):
+def _(os, subprocess):
     if not os.path.exists("data/reference/GRCh38"):
         subprocess.run(
             ["tar", "-xzf", "data/reference/GRCh38.tgz", "-C", "data/reference"],
@@ -280,13 +291,17 @@ def __(subprocess, os):
     print("Reference files ready" if os.path.exists(_critical) else f"ERROR: missing {_critical}")
     return
 
-@app.cell
-def __(mo):
-    mo.md("## 3. Reformat GWAS to harmonizer-compatible format")
-    return
 
 @app.cell
-def __(GWAS_FILE, pd, os, glob, SUMSTATS_FILE):
+def _(mo):
+    mo.md("""
+    ## 3. Reformat GWAS to harmonizer-compatible format
+    """)
+    return
+
+
+@app.cell
+def _(GWAS_FILE, SUMSTATS_FILE, glob, os, pd):
     import gzip as _gzip
     import shutil as _shutil
 
@@ -370,54 +385,110 @@ def __(GWAS_FILE, pd, os, glob, SUMSTATS_FILE):
                 REFORMATTED_GWAS, sep="\t", index=False, compression="gzip"
             )
             print(f"  Written {len(_df):,} variants to {REFORMATTED_GWAS}")
-
     return (REFORMATTED_GWAS,)
 
 
 @app.cell
-def __(mo):
-    mo.md("## 4. Setup harmonization workflow")
+def _(mo):
+    mo.md("""
+    ## 4. Setup harmonization workflow
+    """)
     return
 
 
 @app.cell
-def __(os, Path):
-    
-    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser"
-    HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser/data/gwas_harm_ref"
-    harmonizer_script    = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
+def _(SSF_FILE, SUMSTATS_FILE, np, os, pd):
+    import yaml
+    os.makedirs("data/ldsc_input", exist_ok=True)
 
+    def find_n_deep(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                low_key = str(k).lower()
+                if (('sample' in low_key and 'size' in low_key) or low_key == 'n') and isinstance(v, (int, float)):
+                    return int(v)
+            for v in obj.values():
+                result = find_n_deep(v)
+                if result: return result
+        elif isinstance(obj, list):
+            for item in obj:
+                result = find_n_deep(item)
+                if result: return result
+        return None
 
-
-    nextflow_env = {
-        **os.environ,
-        "PATH": "/mnt/hdd_1/rediet/hypothesis-generation-demo:/mnt/hdd_1/rediet/jdk-17/bin:" + os.environ.get("PATH", ""),
-        "JAVA_HOME": "/mnt/hdd_1/rediet/jdk-17",
-    }
-
-    if not harmonizer_script.exists():
-        print(f"WARNING: 6_harmoniser.sh not found at {harmonizer_script}")
-        harmonizer_ready = False
-    elif not os.path.isdir(HARMONIZER_REF_DIR):
-        print(f"WARNING: Reference directory not found at {HARMONIZER_REF_DIR}")
-        harmonizer_ready = False
+    if os.path.exists(SUMSTATS_FILE):
+        _df_sample = pd.read_csv(SSF_FILE, sep='\t', compression='gzip', nrows=5)
+        print(f"LDSC sumstats file already exists: {SUMSTATS_FILE}")
+        print("Note: Skipping full conversion as file is present.")
     else:
-        print(f"Harmonizer configuration found")
-        print(f"  Script   : {harmonizer_script}")
-        print(f"  Reference: {HARMONIZER_REF_DIR}")
-        harmonizer_ready = True
+        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}")
+        _df = pd.read_csv(SSF_FILE, sep='\t', compression='gzip')
 
-    return (HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, harmonizer_ready, harmonizer_script, nextflow_env)
+        detected_n = None
+        for col in _df.columns:
+            low_col = col.lower()
+            if low_col == 'n' or ('sample' in low_col and 'size' in low_col):
+                detected_n = int(_df[col].max())
+                print(f"N DETECTION: Found N={detected_n} inside the TSV data columns.")
+                break
+        if detected_n is None:
+            file_id = os.path.basename(SSF_FILE).split('-')[0]
+            gwas_dir = os.path.join("data", "gwas")
+            if os.path.exists(gwas_dir):
+                for file in os.listdir(gwas_dir):
+                    if file_id in file and file.endswith(".yaml"):
+                        yaml_path = os.path.join(gwas_dir, file)
+                        with open(yaml_path, 'r') as f:
+                            meta = yaml.safe_load(f)
+                            detected_n = find_n_deep(meta)
+                            if detected_n:
+                                print(f"N DETECTION: Found N={detected_n} via YAML Deep Search ({file}).")
+                                break
+        if detected_n is None:
+            raise ValueError("UNIVERSAL ERROR: Sample size (N) not found in data or metadata.")
+        _df['n'] = detected_n
+        _ldsc = pd.DataFrame()
+        if 'rsid' in _df.columns and (_df['rsid'] != 'NA').any():
+            _ldsc['SNP'] = _df['rsid']
+        else:
+            _ldsc['SNP'] = _df['chromosome'].astype(str) + ':' + _df['base_pair_location'].astype(str)
 
+        _ldsc['A1'] = _df['effect_allele'].str.upper()
+        _ldsc['A2'] = _df['other_allele'].str.upper()
+        _ldsc['Z'] = _df['beta'] / _df['standard_error']
+        _ldsc['N'] = _df['n']
 
-@app.cell
-def __(mo):
-    mo.md("## 5. Harmonize GWAS summary statistics")
+        if 'p_value' in _df.columns:
+            _ldsc['P'] = _df['p_value']
+        _ldsc = _ldsc[np.isfinite(_ldsc['Z'])]
+        _ldsc = _ldsc.drop_duplicates(subset=['SNP'])
+        _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
+        print("\n--- Verification for Mentor ---")
+        print(f"Is 'n' column added to raw _df? {'n' in _df.columns}")
+        print(f"Unique N values in original dataset rows: {_df['n'].unique()}")
+        print(f"LDSC conversion complete using calibrated study size: {detected_n}")
     return
 
 
 @app.cell
-def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, REFORMATTED_GWAS, harmonizer_script, nextflow_env):
+def _(mo):
+    mo.md("""
+    ## 5. Harmonize GWAS summary statistics
+    """)
+    return
+
+
+@app.cell
+def _(
+    HARMONIZER_CODE_REPO,
+    HARMONIZER_REF_DIR,
+    REFORMATTED_GWAS,
+    harmonizer_ready,
+    harmonizer_script,
+    nextflow_env,
+    os,
+    subprocess,
+):
     os.makedirs("data/harmonized", exist_ok=True)
 
     harmonized_found = False
@@ -483,18 +554,26 @@ def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DI
             harmonized_output_dir = None
         finally:
             os.chdir("../..")
-
     return (harmonized_output_dir,)
 
 
 @app.cell
-def __(mo):
-    mo.md("## 6. Convert harmonized output to LDSC format")
+def _(mo):
+    mo.md("""
+    ## 6. Convert harmonized output to LDSC format
+    """)
     return
 
 
 @app.cell
-def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST, REFORMATTED_GWAS):
+def _(
+    REFORMATTED_GWAS,
+    SUMSTATS_FILE,
+    W_HM3_SNPLIST,
+    harmonized_output_dir,
+    os,
+    pd,
+):
     os.makedirs("data/ldsc_input", exist_ok=True)
 
     if harmonized_output_dir is None:
@@ -560,18 +639,26 @@ def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST, REFORMATTED_
             _out.to_csv(SUMSTATS_FILE, sep="\t", index=False, compression="gzip")
             print(f"  Written {len(_out):,} SNPs to {SUMSTATS_FILE}")
             print(f"  Mean |Z|: {_out['Z'].abs().mean():.3f}")
-
     return
 
 
 @app.cell
-def __(mo):
-    mo.md("## 7. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
+def _(mo):
+    mo.md("""
+    ## 7. Generate cell-type-specific binary annotations (BED -> .annot.gz)
+    """)
     return
 
 
 @app.cell
-def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_path):
+def _(
+    all_cell_types,
+    cell_type_beds,
+    ldsc27_path,
+    os,
+    python27_path,
+    subprocess,
+):
     os.makedirs("data/annotations", exist_ok=True)
     _env = os.environ.copy()
     _env["PATH"] = f"{ldsc27_path}/bin:" + _env.get("PATH", "")
@@ -611,13 +698,23 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
 
 
 @app.cell
-def __(mo):
-    mo.md("## 8. Calculate LD scores (HapMap3 SNPs only)")
+def _(mo):
+    mo.md("""
+    ## 8. Calculate LD scores (HapMap3 SNPs only)
+    """)
     return
 
 
 @app.cell
-def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessing, HM3_NO_MHC_LIST):
+def _(
+    HM3_NO_MHC_LIST,
+    all_cell_types,
+    concurrent,
+    multiprocessing,
+    os,
+    python27_path,
+    subprocess,
+):
     os.makedirs("data/ldscores", exist_ok=True)
 
     def _calc_ld(args):
@@ -658,13 +755,15 @@ def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessin
 
 
 @app.cell
-def __(mo):
-    mo.md("## 9. Create CTS reference file")
+def _(mo):
+    mo.md("""
+    ## 9. Create CTS reference file
+    """)
     return
 
 
 @app.cell
-def __(os, all_cell_types, CTS_FILE):
+def _(CTS_FILE, all_cell_types, os):
     os.makedirs("new_results", exist_ok=True)
 
     COMPLETED_CELL_TYPES = []
@@ -687,17 +786,19 @@ def __(os, all_cell_types, CTS_FILE):
             _f.write(f"{_ct}\tdata/ldscores/{_ct}/{_ct}.\n")
 
     print(f"\nCTS file written: {CTS_FILE}  ({len(COMPLETED_CELL_TYPES)} cell types)")
-    return (COMPLETED_CELL_TYPES,)
-
-
-@app.cell
-def __(mo):
-    mo.md("## 10. Run LDSC cell-type-specific heritability analysis")
     return
 
 
 @app.cell
-def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
+def _(mo):
+    mo.md("""
+    ## 10. Run LDSC cell-type-specific heritability analysis
+    """)
+    return
+
+
+@app.cell
+def _(CTS_FILE, RESULTS_PREFIX, SUMSTATS_FILE, os, python27_path, subprocess):
     if not os.path.exists(SUMSTATS_FILE):
         print(f"Skipping — sumstats not found: {SUMSTATS_FILE}")
     elif not os.path.exists(CTS_FILE):
@@ -724,13 +825,15 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
 
 @app.cell
-def __(mo):
-    mo.md("## 11. Results")
+def _(mo):
+    mo.md("""
+    ## 11. Results
+    """)
     return
 
 
 @app.cell
-def __(RESULTS_PREFIX, pd, os):
+def _(RESULTS_PREFIX, os, pd):
     from statsmodels.stats.multitest import fdrcorrection as _fdr
 
     _results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
@@ -754,8 +857,7 @@ def __(RESULTS_PREFIX, pd, os):
         )
         print(f"\nFDR < 0.05: {(ranked['FDR'] < 0.05).sum()} cell types")
         print(f"Saved to  : {RESULTS_PREFIX}_ranked.csv")
-
-    return (ranked,)
+    return
 
 
 if __name__ == "__main__":

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -13,12 +13,11 @@ def __():
     import subprocess
     import pandas as pd
     import numpy as np
-    import tarfile
     from pathlib import Path
     import gzip
     import hashlib
     from datetime import datetime
-    return mo, urllib, os, re, subprocess, pd, np, tarfile, Path, gzip, hashlib, datetime
+    return mo, urllib, os, re, subprocess, pd, np, Path, gzip, hashlib, datetime
 
 
 @app.cell
@@ -35,7 +34,6 @@ All analyses are performed using **GRCh38 / hg38** coordinates.
 @app.cell
 def __(mo):
     GWAS_INPUT_FILE = "data/gwas/atrial_fibrillation.h.tsv.gz"
-
     gwas_stem = mo.state(GWAS_INPUT_FILE)
     return (GWAS_INPUT_FILE, gwas_stem)
 
@@ -53,10 +51,10 @@ def __(GWAS_INPUT_FILE, os):
 
     GWAS_STEM = _re.sub(r"[^A-Za-z0-9_\-]", "_", _no_ext)
 
-    SSF_FILE        = f"data/ssf/{GWAS_STEM}.h.tsv.gz"
-    SSF_YAML        = f"{SSF_FILE}-meta.yaml"
-    SUMSTATS_FILE   = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
-    RESULTS_PREFIX  = f"results/{GWAS_STEM}_CellTypeSpecific"
+    SSF_FILE       = f"data/ssf/{GWAS_STEM}.h.tsv.gz"
+    SSF_YAML       = f"{SSF_FILE}-meta.yaml"
+    SUMSTATS_FILE  = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
+    RESULTS_PREFIX = f"results/{GWAS_STEM}_CellTypeSpecific"
 
     print(f"GWAS stem      : {GWAS_STEM}")
     print(f"SSF file       : {SSF_FILE}")
@@ -68,12 +66,7 @@ def __(GWAS_INPUT_FILE, os):
 
 @app.cell
 def __(mo):
-    mo.md("""
-This cell will:
-1. Create a Python 2.7 conda environment for LDSC
-2. Install LDSC and its dependencies
-3. Install BEDTools (required for annotation generation)
-""")
+    mo.md("## 0. Setup: Download and configure LDSC")
     return
 
 
@@ -83,15 +76,10 @@ def __(Path, subprocess, os):
     LDSC_DIR = TOOLS_DIR / "ldsc"
     TOOLS_DIR.mkdir(exist_ok=True)
 
-    env_check = subprocess.run(
-        ["conda", "env", "list"],
-        capture_output=True,
-        text=True
-    )
+    env_check = subprocess.run(["conda", "env", "list"], capture_output=True, text=True)
     ldsc_env_exists = "ldsc27" in env_check.stdout
 
     if not ldsc_env_exists:
-        print("Creating Python 2.7 conda environment for LDSC...")
         subprocess.run(["conda", "create", "-n", "ldsc27", "python=2.7", "-y"], check=True)
 
     conda_prefix = subprocess.run(
@@ -103,18 +91,13 @@ def __(Path, subprocess, os):
     ldsc27_path = [e for e in envs if "ldsc27" in e][0]
 
     bedtools_path = os.path.join(ldsc27_path, "bin", "bedtools")
-    if os.path.exists(bedtools_path):
-        bedtools_check = subprocess.run([bedtools_path, "--version"], capture_output=True, text=True)
-        print(f"BEDTools already installed: {bedtools_check.stdout.strip()}")
-    else:
-        print("Installing BEDTools in ldsc27 environment...")
+    if not os.path.exists(bedtools_path):
         subprocess.run(
             ["conda", "install", "-n", "ldsc27", "-c", "bioconda", "bedtools", "-y"],
             check=True
         )
 
     if not LDSC_DIR.exists():
-        print("Cloning LDSC repository...")
         subprocess.run(
             ["git", "clone", "https://github.com/bulik/ldsc.git", str(LDSC_DIR)],
             check=True
@@ -126,7 +109,6 @@ def __(Path, subprocess, os):
     )
 
     if check_numpy.returncode != 0:
-        print("Installing LDSC dependencies in ldsc27 environment...")
         subprocess.run(
             ["conda", "install", "-n", "ldsc27", "-y", "openssl=1.0.2", "-c", "conda-forge"],
             check=True
@@ -139,25 +121,9 @@ def __(Path, subprocess, os):
             ["conda", "install", "-n", "ldsc27", "-y", "pybedtools", "pysam=0.15.3", "-c", "bioconda", "-c", "conda-forge"],
             check=True
         )
-        print("Dependencies installed!")
-
-    print("Verifying BEDTools is accessible to pybedtools...")
-    pybedtools_check = subprocess.run(
-        [os.path.join(ldsc27_path, "bin", "python"), "-c",
-         "from pybedtools import BedTool; import pybedtools.helpers as helpers; print('BEDTools path:', helpers.get_bedtools_path())"],
-        capture_output=True, text=True
-    )
-
-    if pybedtools_check.returncode != 0:
-        print("WARNING: pybedtools can't find BEDTools!")
-        print("Error:", pybedtools_check.stderr)
-    else:
-        print("pybedtools can access BEDTools")
-        print(pybedtools_check.stdout)
 
     ldsc_script = LDSC_DIR / "ldsc.py"
     subprocess.run(["chmod", "+x", str(ldsc_script)], check=True)
-
     python27_path = os.path.join(ldsc27_path, "bin", "python")
 
     print(f"LDSC environment ready!")
@@ -174,7 +140,7 @@ def __(mo):
 
 
 @app.cell
-def __(os, urllib, pd, subprocess, re):
+def __(os, urllib, pd, subprocess, re, GWAS_INPUT_FILE):
     os.makedirs("data/peaks", exist_ok=True)
     os.makedirs("data/reference", exist_ok=True)
     os.makedirs("data/gwas", exist_ok=True)
@@ -185,7 +151,6 @@ def __(os, urllib, pd, subprocess, re):
 
     CATLAS_DIR = "humanenhancer_atac_data"
     CATLAS_URL = "http://catlas.org/humanenhancer/data/cCREs/"
-
     BED_SEARCH_DIRS = [CATLAS_DIR, "data/beds"]
 
     def _sanitize_name(raw_name):
@@ -249,15 +214,13 @@ def __(os, urllib, pd, subprocess, re):
     for _raw in sorted(raw_names):
         _safe = _sanitize_name(_raw)
         if _safe in name_conflicts:
-            print(f"  Name collision after sanitization: '{_raw}' -> '{_safe}' (already used by '{name_conflicts[_safe]}')")
             _safe = _safe + "_2"
         name_conflicts[_safe] = _raw
 
         _local = _find_local_bed(_raw)
         if _local:
             cell_type_beds[_safe] = _local
-            marker = "(local BED)" if _raw == _safe else f"(local BED, '{_raw}' -> '{_safe}')"
-            print(f"  {_safe}  ->  {_local}  {marker}")
+            print(f"  {_safe}  ->  {_local}")
         else:
             _bed = _peak_annotation_to_bed(_raw)
             cell_type_beds[_safe] = _bed
@@ -267,14 +230,18 @@ def __(os, urllib, pd, subprocess, re):
     print(f"\n{len(all_cell_types)} cell types ready")
 
     if not os.path.exists("data/reference/GRCh38.tgz"):
-        print("\nDownloading GRCh38 reference with baseline LD scores...")
+        print("Downloading GRCh38 reference...")
         urllib.request.urlretrieve(
             "https://zenodo.org/records/10515792/files/GRCh38.tgz?download=1",
             "data/reference/GRCh38.tgz"
         )
-        print("GRCh38 reference downloaded")
-    else:
-        print("\nGRCh38 reference already downloaded")
+
+    if not os.path.exists("data/reference/hm3_no_MHC.list.txt"):
+        print("Downloading HapMap3 SNP list...")
+        urllib.request.urlretrieve(
+            "https://zenodo.org/records/10515792/files/hm3_no_MHC.list.txt?download=1",
+            "data/reference/hm3_no_MHC.list.txt"
+        )
 
     if not os.path.exists(GWAS_INPUT_FILE):
         print(f"Downloading GWAS summary statistics to {GWAS_INPUT_FILE}...")
@@ -282,9 +249,6 @@ def __(os, urllib, pd, subprocess, re):
             "http://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics/GCST90027001-GCST90028000/GCST90027158/GCST90027158_buildGRCh38.tsv.gz",
             GWAS_INPUT_FILE
         )
-        print("GWAS data downloaded")
-    else:
-        print(f"GWAS data already present: {GWAS_INPUT_FILE}")
 
     print("\nAll sources resolved!")
     return (all_cell_types, cell_type_beds)
@@ -297,46 +261,12 @@ def __(mo):
 
 
 @app.cell
-def __(tarfile, os):
-    print("Checking GRCh38.tgz contents...")
-
-    if os.path.exists("data/reference/GRCh38.tgz"):
-        with tarfile.open("data/reference/GRCh38.tgz", "r:gz") as _tar:
-            members = _tar.getmembers()
-            print(f"Archive contains {len(members)} items")
-            print("\nTop-level structure:")
-            seen = set()
-            for m in members[:50]:
-                parts = m.name.split('/')
-                if len(parts) > 1:
-                    top = parts[0] + "/" + parts[1]
-                    if top not in seen:
-                        print(f"  {top}")
-                        seen.add(top)
-    return
-
-
-@app.cell
-def __(tarfile, os):
-    print("Extracting GRCh38 reference files...")
-
+def __(subprocess, os):
     if not os.path.exists("data/reference/GRCh38"):
-        try:
-            print("  Verifying GRCh38.tgz integrity...")
-            with tarfile.open("data/reference/GRCh38.tgz", "r:gz") as _tar:
-                _tar.getmembers()
-            print("  File integrity verified")
-        except (EOFError, tarfile.ReadError) as e:
-            print(f"\n  Error: GRCh38.tgz is corrupted!")
-            print(f"  Please delete it and re-run: rm data/reference/GRCh38.tgz")
-            raise
-
-        print("  Extracting...")
-        with tarfile.open("data/reference/GRCh38.tgz", "r:gz") as _tar:
-            _tar.extractall("data/reference")
-        print("GRCh38 reference extracted successfully")
-    else:
-        print("GRCh38 directory exists")
+        subprocess.run(
+            ["tar", "-xzf", "data/reference/GRCh38.tgz", "-C", "data/reference"],
+            check=True
+        )
 
     nested_files = [
         ("data/reference/GRCh38/baselineLD_v2.2.tgz", "data/reference", "baselineLD_v2.2"),
@@ -345,35 +275,17 @@ def __(tarfile, os):
     ]
 
     for tar_file, extract_to, check_file in nested_files:
-        check_path = os.path.join(extract_to, check_file)
-        if os.path.exists(check_path):
-            print(f"  {os.path.basename(tar_file)} already extracted")
+        _check_path = os.path.join(extract_to, check_file)
+        if os.path.exists(_check_path):
             continue
-
         if os.path.exists(tar_file):
-            print(f"  Extracting {os.path.basename(tar_file)}...")
-            with tarfile.open(tar_file, "r:gz") as _tar:
-                _tar.extractall(extract_to)
-            print(f"  {os.path.basename(tar_file)} extracted")
+            subprocess.run(["tar", "-xzf", tar_file, "-C", extract_to], check=True)
 
-            if not os.path.exists(check_path):
-                print(f"  Warning: Expected file {check_path} not found after extraction")
-        else:
-            print(f"  Warning: {tar_file} not found")
-
-    critical_file = "data/reference/GRCh38/plink_files/1000G.EUR.hg38.1.bim"
-    if os.path.exists(critical_file):
-        print(f"\nAll reference files ready! Verified: {critical_file}")
+    _critical = "data/reference/GRCh38/plink_files/1000G.EUR.hg38.1.bim"
+    if os.path.exists(_critical):
+        print("All reference files ready!")
     else:
-        print(f"\nERROR: Critical file missing: {critical_file}")
-        print("Checking what files exist in data/reference/GRCh38/:")
-        if os.path.exists("data/reference/GRCh38"):
-            files = os.listdir("data/reference/GRCh38")
-            print(f"  Found {len(files)} files/directories")
-            for _f in sorted(files)[:10]:
-                print(f"    - {_f}")
-        else:
-            print("  Directory doesn't exist!")
+        print(f"ERROR: Critical file missing: {_critical}")
 
     return
 
@@ -389,7 +301,7 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
     os.makedirs("data/ssf", exist_ok=True)
 
     if os.path.exists(SSF_FILE):
-        print(f"SSF file already exists, skipping conversion: {SSF_FILE}")
+        print(f"SSF file already exists, skipping: {SSF_FILE}")
     else:
         print(f"Converting {GWAS_INPUT_FILE} -> {SSF_FILE}")
 
@@ -409,7 +321,7 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
             _col_map['other_allele'] = _cols_lower.get('a2') or _cols_lower.get('other_allele')
 
         _col_map['beta'] = _cols_lower.get('beta')
-        _col_map['standard_error'] = (_cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error'))
+        _col_map['standard_error'] = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error')
         _col_map['p_value'] = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value')
         _col_map['effect_allele_frequency'] = (
             _cols_lower.get('a1_freq') or _cols_lower.get('frq') or
@@ -419,6 +331,7 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
             _cols_lower.get('id') or _cols_lower.get('snp') or
             _cols_lower.get('rsid') or _cols_lower.get('variant_id')
         )
+        _col_map['n_total'] = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
 
         if "variant" not in _cols_lower:
             _rename_map = {v: k for k, v in _col_map.items() if v is not None}
@@ -427,7 +340,6 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
         _df['chromosome'] = _df['chromosome'].astype(str).str.replace('chr', '', regex=False)
         _df['chromosome'] = _df['chromosome'].replace({'23': 'X', '24': 'Y', '26': 'MT'})
 
-        print("Filtering chromosomes (removing X, Y, MT)...")
         _before = len(_df)
         _df = _df[~_df['chromosome'].isin(['X', 'Y', 'MT'])]
         print(f"  Removed {_before - len(_df)} variants on sex/MT chromosomes")
@@ -435,51 +347,37 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
         _df['base_pair_location'] = pd.to_numeric(_df['base_pair_location'], errors='coerce')
         _df['effect_allele'] = _df['effect_allele'].str.upper()
         _df['other_allele'] = _df['other_allele'].str.upper()
+        _df['effect_allele_frequency'] = _df['effect_allele_frequency'].fillna('NA') if 'effect_allele_frequency' in _df.columns else 'NA'
+        _df['rsid'] = _df['rsid'].fillna('NA') if 'rsid' in _df.columns else 'NA'
 
-        if 'effect_allele_frequency' in _df.columns:
-            _df['effect_allele_frequency'] = _df['effect_allele_frequency'].fillna('NA')
-        else:
-            _df['effect_allele_frequency'] = 'NA'
+        _ssf_cols = ['chromosome', 'base_pair_location', 'effect_allele', 'other_allele',
+                     'beta', 'standard_error', 'p_value', 'effect_allele_frequency', 'rsid']
+        if 'n_total' in _df.columns:
+            _ssf_cols.append('n_total')
 
-        if 'rsid' in _df.columns:
-            _df['rsid'] = _df['rsid'].fillna('NA')
-        else:
-            _df['rsid'] = 'NA'
-
-        ssf_columns = ['chromosome', 'base_pair_location', 'effect_allele', 'other_allele',
-                       'beta', 'standard_error', 'p_value', 'effect_allele_frequency', 'rsid']
-        _df_ssf = _df[ssf_columns]
-
-        print(f"Writing SSF file: {SSF_FILE}")
+        _df_ssf = _df[_ssf_cols]
         _df_ssf.to_csv(SSF_FILE, sep="\t", index=False, compression="gzip")
 
-        print("Creating tabix index...")
         subprocess.run(
             ["tabix", "-c", "N", "-S", "1", "-s", "1", "-b", "2", "-e", "2", SSF_FILE],
             check=False
         )
 
-        with gzip.open(SSF_FILE, 'rb') as f:
-            _md5 = hashlib.md5(f.read()).hexdigest()
+        with gzip.open(SSF_FILE, 'rb') as _f:
+            _md5 = hashlib.md5(_f.read()).hexdigest()
 
         with open(SSF_YAML, 'w') as _f:
             _f.write(f"""# Study meta-data
-date_metadata_last_modified: {datetime.now().strftime('%Y-%m-%d')}
-
+date_metadata_last_modified: {datetime.now().strftime('%Y-%m-%d')} 
 genome_assembly: GRCh38
 coordinate_system: 1-based
-
 data_file_name: {os.path.basename(SSF_FILE)}
 file_type: GWAS-SSF v0.1
 data_file_md5sum: {_md5}
-
 is_harmonised: false
 is_sorted: false
 """)
-
         print("SSF conversion complete")
-        chromosomes_present = sorted(_df_ssf['chromosome'].unique(), key=lambda x: int(x))
-        print(f"Chromosomes in data: {', '.join(chromosomes_present)}")
 
     return
 
@@ -512,20 +410,19 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
                 _df.loc[_missing, 'base_pair_location'].astype(str)
             )
         else:
-            _ldsc['SNP'] = (
-                _df['chromosome'].astype(str) + ':' +
-                _df['base_pair_location'].astype(str)
-            )
+            _ldsc['SNP'] = _df['chromosome'].astype(str) + ':' + _df['base_pair_location'].astype(str)
 
         _ldsc['A1'] = _df['effect_allele'].str.upper()
         _ldsc['A2'] = _df['other_allele'].str.upper()
         _ldsc['Z'] = _df['beta'] / _df['standard_error']
 
-        _n_cases = 111326
-        _n_controls = 677663
-        _effective_n = 4 / (1/_n_cases + 1/_n_controls)
-        _ldsc['N'] = int(_effective_n)
-        print(f"Using effective sample size: {int(_effective_n):,}")
+        _n_col = next((c for c in _df.columns if c.lower() in ['n', 'n_total', 'sample_size']), None)
+        if _n_col:
+            _ldsc['N'] = _df[_n_col]
+            print(f"Using N from column '{_n_col}' (median: {int(_df[_n_col].median()):,})")
+        else:
+            print("WARNING: No N column found. Columns available:", list(_df.columns))
+            _ldsc['N'] = np.nan
 
         if 'p_value' in _df.columns:
             _ldsc['P'] = _df['p_value']
@@ -541,15 +438,13 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
             print(f"Removed {_before - len(_ldsc)} duplicate variants")
 
         print(f"Output: {len(_ldsc)} variants")
-
         _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
 
         print(f"LDSC format conversion complete")
         print(f"  Mean |Z|: {_ldsc['Z'].abs().mean():.3f}")
         print(f"  Median |Z|: {_ldsc['Z'].abs().median():.3f}")
         if 'P' in _ldsc.columns:
-            _sig = (_ldsc['P'] < 5e-8).sum()
-            print(f"  Genome-wide significant (P < 5e-8): {_sig:,}")
+            print(f"  Genome-wide significant (P < 5e-8): {(_ldsc['P'] < 5e-8).sum():,}")
 
     return
 
@@ -581,8 +476,8 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
         _bed_file = cell_type_beds[_ct]
 
         for _chrom in range(1, 23):
-            annot_file = f"data/annotations/{_ct}.{_chrom}.annot.gz"
-            if os.path.exists(annot_file):
+            _annot_file = f"data/annotations/{_ct}.{_chrom}.annot.gz"
+            if os.path.exists(_annot_file):
                 print(f"  Chromosome {_chrom} (exists)", end=" ", flush=True)
                 continue
 
@@ -591,13 +486,12 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
                 python27_path, "tools/ldsc/make_annot.py",
                 "--bed-file", _bed_file,
                 "--bimfile", f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_chrom}.bim",
-                "--annot-file", annot_file
+                "--annot-file", _annot_file
             ], capture_output=True, text=True, env=env)
 
             if _result.returncode != 0:
-                print(f"\n\nERROR on chromosome {_chrom}:")
+                print(f"\nERROR on chromosome {_chrom}:")
                 print("STDERR:", _result.stderr)
-                print("STDOUT:", _result.stdout)
                 raise subprocess.CalledProcessError(_result.returncode, _result.args)
             print("done")
         print(f"  {_ct} complete")
@@ -608,48 +502,55 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
 
 @app.cell
 def __(mo):
-    mo.md("## 6. Calculate LD scores for each cell type and chromosome")
+    mo.md("## 6. Calculate LD scores for each cell type and chromosome (HapMap3 SNPs only)")
     return
 
 
 @app.cell
 def __(subprocess, os, all_cell_types, python27_path):
+    import concurrent.futures
+    import multiprocessing
+
     os.makedirs("data/ldscores", exist_ok=True)
+    HM3_SNP_LIST = "data/reference/hm3_no_MHC.list.txt"
+    def calculate_single_chrom(args):
+        ct, chrom = args
+        out_dir = f"data/ldscores/{ct}"
+        os.makedirs(out_dir, exist_ok=True)
+        
+        ldscore_file = f"{out_dir}/{ct}.{chrom}.l2.ldscore.gz"
+        if os.path.exists(ldscore_file):
+            return f"[{ct}] Chr {chrom} already exists. Skipping."
 
-    for _ct in all_cell_types:
-        print(f"\nProcessing {_ct}...")
-        os.makedirs(f"data/ldscores/{_ct}", exist_ok=True)
-
-        _all_exist = all(
-            os.path.exists(f"data/ldscores/{_ct}/{_ct}.{_chrom}.l2.ldscore.gz")
-            for _chrom in range(1, 23)
-        )
-
-        if _all_exist:
-            print(f"  All {_ct} LD scores already exist, skipping")
-            continue
-
-        for _chrom in range(1, 23):
-            ldscore_file = f"data/ldscores/{_ct}/{_ct}.{_chrom}.l2.ldscore.gz"
-            if os.path.exists(ldscore_file):
-                print(f"  Chromosome {_chrom} (exists)", end=" ", flush=True)
-                continue
-
-            print(f"  Chromosome {_chrom}...", end=" ", flush=True)
+        try:
             subprocess.run([
                 python27_path, "tools/ldsc/ldsc.py",
                 "--l2",
-                "--bfile", f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_chrom}",
+                "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{chrom}",
                 "--ld-wind-cm", "1.0",
-                "--annot", f"data/annotations/{_ct}.{_chrom}.annot.gz",
+                "--annot",      f"data/annotations/{ct}.{chrom}.annot.gz",
                 "--thin-annot",
-                "--out", f"data/ldscores/{_ct}/{_ct}.{_chrom}"
+                "--print-snps", HM3_SNP_LIST,
+                "--out",        f"{out_dir}/{ct}.{chrom}"
             ], check=True, capture_output=True)
-            print("done")
-        print(f"  {_ct} complete")
+            return f"[{ct}] Chr {chrom} calculation complete."
+        except subprocess.CalledProcessError as e:
+            return f"ERROR on [{ct}] Chr {chrom}: {e.stderr}"
+    tasks = []
+    for ct in all_cell_types:
+        for chrom in range(1, 23):
+            tasks.append((ct, chrom))
+    max_workers = min(multiprocessing.cpu_count() - 1, 6) 
+    
+    print(f"Starting parallel LDSC calculation with {max_workers} workers...")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for result in executor.map(calculate_single_chrom, tasks):
+            print(result)
 
-    print("\nAll LD scores calculated")
+    print("\nAll LD scores calculated using HapMap3 SNPs")
     return
+
+
 
 
 @app.cell
@@ -662,11 +563,26 @@ def __(mo):
 def __(os, all_cell_types, GWAS_STEM):
     os.makedirs("results", exist_ok=True)
     cts_path = f"data/{GWAS_STEM}_cell_types.cts"
+
+    COMPLETED_CELL_TYPES = []
+    for _ct in all_cell_types:
+        _all_exist = all(
+            os.path.exists(f"data/ldscores/{_ct}/{_ct}.{_chrom}.l2.ldscore.gz")
+            for _chrom in range(1, 23)
+        )
+        if _all_exist:
+            COMPLETED_CELL_TYPES.append(_ct)
+            print(f"  {_ct}: complete")
+        else:
+            _missing = [c for c in range(1, 23) if not os.path.exists(f"data/ldscores/{_ct}/{_ct}.{c}.l2.ldscore.gz")]
+            print(f"  {_ct}: INCOMPLETE (missing chromosomes: {_missing})")
+
     with open(cts_path, "w") as _f:
-        for _ct in all_cell_types:
+        for _ct in COMPLETED_CELL_TYPES:
             _f.write(f"{_ct}\tdata/ldscores/{_ct}/{_ct}.\n")
-    print(f"CTS reference file created: {cts_path} ({len(all_cell_types)} cell types)")
-    return (cts_path,)
+
+    print(f"\nCTS file written with {len(COMPLETED_CELL_TYPES)} complete cell types: {cts_path}")
+    return (cts_path, COMPLETED_CELL_TYPES)
 
 
 @app.cell
@@ -676,101 +592,58 @@ def __(mo):
 
 
 @app.cell
-def __(all_cell_types, python27_path, SUMSTATS_FILE, GWAS_STEM, RESULTS_PREFIX, os, pd, datetime):
-    from concurrent.futures import ProcessPoolExecutor, as_completed
+def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
-    BATCH_SIZE  = 25
-    MAX_WORKERS = 4
+    if not os.path.exists(SUMSTATS_FILE):
+        print(f"Skipping - sumstats file not found: {SUMSTATS_FILE}")
 
-    def run_cts_batch(args):
-        batch_idx, cell_type_subset, py_path, sumstats, gwas_stem = args
-        import os, subprocess
-        cts_path = f"data/{gwas_stem}_cell_types_batch_{batch_idx}.cts"
-        with open(cts_path, "w") as f:
-            for ct in cell_type_subset:
-                f.write(f"{ct}\tdata/ldscores/{ct}/{ct}.\n")
+    elif not os.path.exists(cts_path):
+        print(f"Skipping - CTS file not found: {cts_path}")
 
-        out_prefix  = f"results/{gwas_stem}_CTS_batch_{batch_idx}"
-        result_path = f"{out_prefix}.cell_type_results.txt"
-        if os.path.exists(result_path):
-            return batch_idx, True, "already exists"
+    else:
+        os.makedirs("results", exist_ok=True)
 
-        r = subprocess.run([
-            py_path, "tools/ldsc/ldsc.py",
-            "--h2-cts",         sumstats,
+        print("Running LDSC cell-type–specific heritability analysis (single run)...")
+
+        subprocess.run([
+            python27_path, "tools/ldsc/ldsc.py",
+            "--h2-cts",         SUMSTATS_FILE,
             "--ref-ld-chr",     "data/reference/baselineLD_v2.2/baselineLD.",
             "--ref-ld-chr-cts", cts_path,
             "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
-            "--out",            out_prefix,
-        ], capture_output=True, text=True)
+            "--out",            RESULTS_PREFIX,
+        ], check=True)
 
-        if r.returncode != 0:
-            return batch_idx, False, r.stderr[:300]
-        return batch_idx, True, "ok"
-
-    if SUMSTATS_FILE is None or not os.path.exists(SUMSTATS_FILE):
-        print(f"Skipping LDSC analysis - sumstats file not found: {SUMSTATS_FILE}")
-    else:
-        os.makedirs("results", exist_ok=True)
-        batches = [all_cell_types[i:i+BATCH_SIZE] for i in range(0, len(all_cell_types), BATCH_SIZE)]
-        print(f"Running {len(batches)} batches of <=={BATCH_SIZE} cell types, {MAX_WORKERS} workers")
-        print(f"Started: {datetime.now().strftime('%H:%M:%S')}")
-
-        tasks  = [(i, b, python27_path, SUMSTATS_FILE, GWAS_STEM) for i, b in enumerate(batches)]
-        failed = []
-        with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
-            futures = {pool.submit(run_cts_batch, t): t[0] for t in tasks}
-            for fut in as_completed(futures):
-                idx, ok, msg = fut.result()
-                print(f"  {'done' if ok else 'FAILED'} Batch {idx:03d} -> {msg}")
-                if not ok:
-                    failed.append(idx)
-
-        print(f"Finished: {datetime.now().strftime('%H:%M:%S')}")
-        if failed:
-            print(f"Failed batches: {failed}")
-
-        dfs = []
-        for i in range(len(batches)):
-            p = f"results/{GWAS_STEM}_CTS_batch_{i}.cell_type_results.txt"
-            if os.path.exists(p):
-                dfs.append(pd.read_csv(p, sep="\t"))
-
-        if dfs:
-            _ranked = pd.concat(dfs, ignore_index=True).sort_values("Coefficient_P_value")
-            _ranked_csv = f"{RESULTS_PREFIX}_ranked.csv"
-            _ranked_tsv = f"{RESULTS_PREFIX}.cell_type_results.txt"
-            _ranked.to_csv(_ranked_csv, index=False)
-            _ranked.to_csv(_ranked_tsv, sep="\t", index=False)
-            print(f"\nMerged {len(_ranked)} cell types -> {_ranked_csv}")
-            print(_ranked[["Name","Coefficient","Coefficient_std_error","Coefficient_P_value"]].head(10).to_string(index=False))
+        print("LDSC CTS analysis completed")
 
     return
-
-
-@app.cell
-def __(mo):
-    mo.md("## 9. Rank cell types by heritability enrichment significance")
-    return
-
-
 @app.cell
 def __(RESULTS_PREFIX, pd, os):
     results_file = f"{RESULTS_PREFIX}.cell_type_results.txt"
 
     if not os.path.exists(results_file):
         print(f"Results file not found: {results_file}")
-        print("Please run Step 8 first to generate the cell-type-specific analysis results.")
         ranked = None
     else:
         results = pd.read_csv(results_file, sep="\t")
-        ranked = results.sort_values("Coefficient_P_value")
-        _ranked_csv = f"{RESULTS_PREFIX}_ranked.csv"
-        ranked.to_csv(_ranked_csv, index=False)
 
-        print("Cell types ranked by heritability enrichment p-value:\n")
-        print(ranked[["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value"]].to_string(index=False))
-        print(f"\nResults saved to {_ranked_csv}")
+        ranked = results.sort_values("Coefficient_P_value")
+
+        ranked_csv = f"{RESULTS_PREFIX}_ranked_by_pvalue.csv"
+        ranked_txt = f"{RESULTS_PREFIX}_ranked_by_pvalue.txt"
+
+        ranked.to_csv(ranked_csv, index=False)
+        ranked.to_csv(ranked_txt, sep="\t", index=False)
+
+        print("\nTop enriched cell types:\n")
+        print(
+            ranked[
+                ["Name", "Coefficient", "Coefficient_std_error", "Coefficient_P_value"]
+            ].head(10).to_string(index=False)
+        )
+
+        print(f"\nRanked CSV saved to: {ranked_csv}")
+        print(f"Ranked TXT saved to: {ranked_txt}")
 
     return (ranked,)
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -28,23 +28,23 @@ from *Epigenomic dissection of Alzheimer's disease pinpoints causal variants and
 
 All analyses are performed using **GRCh38 / hg38** coordinates.
 """)
-    return 
+    return
 
 
 @app.cell
 def __(mo):
-    GWAS_INPUT_FILE = "data/gwas/28714975-GCST004787-EFO_0001645.h.tsv.gz.2"
+    GWAS_INPUT_FILE = "data/gwas/6152_9.gwas.imputed_v3.both_sexes.tsv.bgz"
     gwas_stem = mo.state(GWAS_INPUT_FILE)
     return (GWAS_INPUT_FILE, gwas_stem)
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, os): 
+def __(GWAS_INPUT_FILE, os):
     import re as _re
 
     _basename = os.path.basename(GWAS_INPUT_FILE)
     _no_ext = _basename
-    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv"]: 
+    for _ext in [".tsv.gz", ".txt.gz", ".gz", ".tsv", ".txt", ".csv"]:
         if _no_ext.endswith(_ext):
             _no_ext = _no_ext[: -len(_ext)]
             break
@@ -297,7 +297,7 @@ def __(mo):
 
 
 @app.cell
-def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, datetime): 
+def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, datetime):
     os.makedirs("data/ssf", exist_ok=True)
 
     if os.path.exists(SSF_FILE):
@@ -305,51 +305,85 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
     else:
         print(f"Converting {GWAS_INPUT_FILE} -> {SSF_FILE}")
 
-        _df = pd.read_csv(GWAS_INPUT_FILE, sep="\t", compression="gzip")
+        _compression = "gzip" if GWAS_INPUT_FILE.endswith((".gz", ".bgz")) else None
+        _sep = r"\s+" if GWAS_INPUT_FILE.endswith((".txt", ".txt.gz")) else "\t"
+        _engine = "c" if GWAS_INPUT_FILE.endswith(".bgz") else "python"
+        _df = pd.read_csv(GWAS_INPUT_FILE, sep=_sep, compression=_compression, engine=_engine)
+
+        print(f"  Columns detected: {list(_df.columns)}")
 
         _has_hm = any(c.startswith("hm_") for c in _df.columns) and _df['hm_chrom'].notna().any()
 
         if _has_hm:
             print("Detected GWAS Catalog harmonised format (hm_ columns)")
             _df2 = pd.DataFrame()
-            _df2['chromosome']            = _df['hm_chrom'].astype(str)
-            _df2['base_pair_location']    = pd.to_numeric(_df['hm_pos'], errors='coerce')
-            _df2['effect_allele']         = _df['hm_effect_allele'].str.upper()
-            _df2['other_allele']          = _df['hm_other_allele'].str.upper()
-            _df2['beta']                  = pd.to_numeric(_df['hm_beta'], errors='coerce')
-            _df2['standard_error']        = pd.to_numeric(_df['standard_error'], errors='coerce')
-            _df2['p_value']               = pd.to_numeric(_df['p_value'], errors='coerce')
+            _df2['chromosome']              = _df['hm_chrom'].astype(str)
+            _df2['base_pair_location']      = pd.to_numeric(_df['hm_pos'], errors='coerce')
+            _df2['effect_allele']           = _df['hm_effect_allele'].str.upper()
+            _df2['other_allele']            = _df['hm_other_allele'].str.upper()
+            _df2['beta']                    = pd.to_numeric(_df['hm_beta'], errors='coerce')
+            _df2['standard_error']          = pd.to_numeric(_df['standard_error'], errors='coerce')
+            _df2['p_value']                 = pd.to_numeric(_df['p_value'], errors='coerce')
             _df2['effect_allele_frequency'] = pd.to_numeric(_df['hm_effect_allele_frequency'], errors='coerce').fillna('NA')
-            _df2['rsid']                  = _df['hm_rsid'].fillna('NA')
+            _df2['rsid']                    = _df['hm_rsid'].fillna('NA')
             _df = _df2
         else:
             _cols_lower = {col.lower(): col for col in _df.columns}
+
             if "variant" in _cols_lower:
                 print("Detected Neale format")
                 _df[['chromosome', 'base_pair_location', 'other_allele', 'effect_allele']] = \
                     _df[_cols_lower['variant']].str.split(':', expand=True)
+                _cols_lower = {col.lower(): col for col in _df.columns}
+                _col_map = {}
+                _col_map['standard_error'] = _cols_lower.get('se') or _cols_lower.get('stderr')
+                _col_map['p_value']        = _cols_lower.get('pval') or _cols_lower.get('p_value') or _cols_lower.get('p')
+                _col_map['n_total']        = _cols_lower.get('n_complete_samples') or _cols_lower.get('n') or _cols_lower.get('n_total')
+                _col_map['effect_allele_frequency'] = _cols_lower.get('minor_af') or _cols_lower.get('af') or _cols_lower.get('freq')
+                _rename_map = {v: k for k, v in _col_map.items() if v is not None}
+                _df = _df.rename(columns=_rename_map)
             else:
                 print("Detected PLINK/standard format")
                 _col_map = {}
-                _col_map['chromosome']          = _cols_lower.get('chr') or _cols_lower.get('chrom') or _cols_lower.get('chromosome')
-                _col_map['base_pair_location']  = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
-                _col_map['effect_allele']       = _cols_lower.get('a1') or _cols_lower.get('effect_allele')
-                _col_map['other_allele']        = _cols_lower.get('a2') or _cols_lower.get('other_allele')
-                _col_map['beta'] = _cols_lower.get('beta') or _cols_lower.get('logor')
-                _col_map['n_total'] = _cols_lower.get('n_samples') or _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('sample_size')
-                _col_map['standard_error']      = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error')
-                _col_map['p_value']             = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value')
-                _col_map['effect_allele_frequency'] = _cols_lower.get('a1_freq') or _cols_lower.get('frq') or _cols_lower.get('af') or _cols_lower.get('effect_allele_frequency')
-                _col_map['rsid']                = _cols_lower.get('id') or _cols_lower.get('snp') or _cols_lower.get('rsid') or _cols_lower.get('variant_id')
+                _col_map['chromosome']              = _cols_lower.get('chr') or _cols_lower.get('chrom') or _cols_lower.get('chromosome')
+                _col_map['base_pair_location']      = _cols_lower.get('bp') or _cols_lower.get('pos') or _cols_lower.get('base_pair_location')
+                _col_map['effect_allele']           = _cols_lower.get('a1') or _cols_lower.get('effect_allele') or _cols_lower.get('allele1') or _cols_lower.get('alt')
+                _col_map['other_allele']            = _cols_lower.get('a2') or _cols_lower.get('other_allele') or _cols_lower.get('allele2') or _cols_lower.get('ref')
+                _col_map['beta']                    = _cols_lower.get('beta') or _cols_lower.get('logor') or _cols_lower.get('log_odds') or _cols_lower.get('effect')
+                _col_map['standard_error']          = _cols_lower.get('se') or _cols_lower.get('stderr') or _cols_lower.get('standard_error') or _cols_lower.get('stderrlogor') or _cols_lower.get('se_beta')
+                _col_map['p_value']                 = _cols_lower.get('p') or _cols_lower.get('pval') or _cols_lower.get('p_value') or _cols_lower.get('pvalue') or _cols_lower.get('p.value')
+                _col_map['effect_allele_frequency'] = _cols_lower.get('freq') or _cols_lower.get('a1_freq') or _cols_lower.get('frq') or _cols_lower.get('af') or _cols_lower.get('eaf') or _cols_lower.get('effect_allele_frequency')
+                _col_map['rsid']                    = _cols_lower.get('markername') or _cols_lower.get('snp') or _cols_lower.get('rsid') or _cols_lower.get('id') or _cols_lower.get('variant_id') or _cols_lower.get('snpid')
+                _col_map['n_total']                 = _cols_lower.get('n') or _cols_lower.get('n_total') or _cols_lower.get('n_samples') or _cols_lower.get('sample_size') or _cols_lower.get('neff')
+
                 _rename_map = {v: k for k, v in _col_map.items() if v is not None}
                 _df = _df.rename(columns=_rename_map)
 
-        _df['chromosome'] = _df['chromosome'].astype(str).str.replace('chr', '', regex=False)
-        _df['chromosome'] = _df['chromosome'].replace({'23': 'X', '24': 'Y', '26': 'MT'})
+                if 'effect_allele' in _df.columns:
+                    _df['effect_allele'] = _df['effect_allele'].astype(str).str.upper()
+                if 'other_allele' in _df.columns:
+                    _df['other_allele'] = _df['other_allele'].astype(str).str.upper()
 
-        _before = len(_df)
-        _df = _df[~_df['chromosome'].isin(['X', 'Y', 'MT'])]
-        print(f"  Removed {_before - len(_df)} variants on sex/MT chromosomes")
+        if 'chromosome' in _df.columns:
+            _df['chromosome'] = _df['chromosome'].astype(str).str.replace('chr', '', regex=False).str.strip()
+            _df['chromosome'] = _df['chromosome'].replace({'23': 'X', '24': 'Y', '26': 'MT'})
+            _before = len(_df)
+            _df = _df[~_df['chromosome'].isin(['X', 'Y', 'MT', 'nan', 'None', ''])]
+            _df = _df.dropna(subset=['chromosome', 'base_pair_location'])
+            _df = _df[_df['chromosome'].astype(str).str.strip().str.match(r'^\d+$')]
+            print(f"  Removed {_before - len(_df)} variants on sex/MT/invalid chromosomes")
+        else:
+            print("  No chromosome column found — will use rsID for SNP matching")
+
+        if 'effect_allele_frequency' not in _df.columns:
+            _df['effect_allele_frequency'] = 'NA'
+        else:
+            _df['effect_allele_frequency'] = _df['effect_allele_frequency'].fillna('NA')
+
+        if 'rsid' not in _df.columns:
+            _df['rsid'] = 'NA'
+        else:
+            _df['rsid'] = _df['rsid'].fillna('NA')
 
         _ssf_cols = ['chromosome', 'base_pair_location', 'effect_allele', 'other_allele',
                      'beta', 'standard_error', 'p_value', 'effect_allele_frequency', 'rsid']
@@ -357,6 +391,10 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
             _ssf_cols.append('n_total')
 
         _df_ssf = _df[[c for c in _ssf_cols if c in _df.columns]]
+
+        print(f"  SSF columns: {list(_df_ssf.columns)}")
+        print(f"  SSF rows: {len(_df_ssf)}")
+
         _df_ssf.to_csv(SSF_FILE, sep="\t", index=False, compression="gzip")
 
         subprocess.run(
@@ -369,13 +407,13 @@ def __(GWAS_INPUT_FILE, SSF_FILE, SSF_YAML, pd, os, gzip, subprocess, hashlib, d
 
         with open(SSF_YAML, 'w') as _f:
             _f.write(f"""# Study meta-data
-date_metadata_last_modified: {datetime.now().strftime('%Y-%m-%d')} 
+date_metadata_last_modified: {datetime.now().strftime('%Y-%m-%d')}
 genome_assembly: GRCh38
 coordinate_system: 1-based
 data_file_name: {os.path.basename(SSF_FILE)}
 file_type: GWAS-SSF v0.1
 data_file_md5sum: {_md5}
-is_harmonised: true
+is_harmonised: false
 is_sorted: false
 """)
         print("SSF conversion complete")
@@ -388,7 +426,7 @@ def __(mo):
     mo.md("## 4. Convert SSF to LDSC format")
     return
 
-#TODO: Extract "N" directly from the metadata
+
 @app.cell
 def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
     os.makedirs("data/ldsc_input", exist_ok=True)
@@ -396,28 +434,36 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
     if os.path.exists(SUMSTATS_FILE):
         print(f"LDSC sumstats file already exists: {SUMSTATS_FILE}")
     else:
-        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}") 
+        print(f"Converting {SSF_FILE} -> {SUMSTATS_FILE}")
 
         _df = pd.read_csv(SSF_FILE, sep='\t', compression='gzip')
         print(f"Input: {len(_df)} variants")
 
-        _ldsc = pd.DataFrame() 
+        _ldsc = pd.DataFrame()
 
-        if 'rsid' in _df.columns and (_df['rsid'] != 'NA').any():
-            _ldsc['SNP'] = _df['rsid']
-            _missing = (_ldsc['SNP'].isna()) | (_ldsc['SNP'] == 'NA')
-            _ldsc.loc[_missing, 'SNP'] = (
-                _df.loc[_missing, 'chromosome'].astype(str) + ':' +
-                _df.loc[_missing, 'base_pair_location'].astype(str)
+        _has_rsid = 'rsid' in _df.columns and (_df['rsid'] != 'NA').any() and _df['rsid'].notna().any()
+        _has_chrpos = 'chromosome' in _df.columns and 'base_pair_location' in _df.columns
+
+        if _has_rsid:
+            _ldsc['SNP'] = _df['rsid'].astype(str)
+            if _has_chrpos:
+                _missing = (_ldsc['SNP'].isna()) | (_ldsc['SNP'] == 'NA') | (_ldsc['SNP'] == 'nan')
+                _ldsc.loc[_missing, 'SNP'] = (
+                    _df.loc[_missing, 'chromosome'].astype(float).astype(int).astype(str) + ':' +
+                    _df.loc[_missing, 'base_pair_location'].astype(float).astype(int).astype(str)
+                )
+        elif _has_chrpos:
+            _ldsc['SNP'] = (
+                _df['chromosome'].astype(float).astype(int).astype(str) + ':' +
+                _df['base_pair_location'].astype(float).astype(int).astype(str)
             )
         else:
-            _ldsc['SNP'] = _df['chromosome'].astype(str) + ':' + _df['base_pair_location'].astype(str)
+            raise ValueError("No SNP identifier found — need either rsid or chromosome:position columns")
 
-        _ldsc['A1'] = _df['effect_allele'].str.upper()
-        _ldsc['A2'] = _df['other_allele'].str.upper()
+        _ldsc['A1'] = _df['effect_allele'].astype(str).str.upper()
+        _ldsc['A2'] = _df['other_allele'].astype(str).str.upper()
         _ldsc['Z']  = pd.to_numeric(_df['beta'], errors='coerce') / pd.to_numeric(_df['standard_error'], errors='coerce')
-        _ldsc['N']  = 63731
-        print("Using hardcoded N (Nielsen et al. 2018 AF GWAS)")
+        _ldsc['N']  = 360527
 
         if 'p_value' in _df.columns:
             _ldsc['P'] = pd.to_numeric(_df['p_value'], errors='coerce')
@@ -433,6 +479,7 @@ def __(SSF_FILE, SUMSTATS_FILE, pd, np, os):
             print(f"Removed {_before - len(_ldsc)} duplicate variants")
 
         print(f"Output: {len(_ldsc)} variants")
+        print(f"  Sample SNP IDs: {list(_ldsc['SNP'].head(3))}")
         _ldsc.to_csv(SUMSTATS_FILE, sep='\t', index=False, compression='gzip')
 
         print(f"LDSC format conversion complete")

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -39,7 +39,7 @@ def __(mo):
 @app.cell
 def __(mo, os):
     GWAS_INPUT_FILE = mo.ui.text(
-        value="data/gwas/UKBB.GWAS1KG.EXOME.CAD.SOFT.META.PublicRelease.300517.txt.gz",
+        value="data/gwas/PGC_UKB_depression_genome-wide.txt",
         label="GWAS input file path",
         full_width=True,
     )
@@ -79,7 +79,7 @@ def __(GWAS_INPUT_FILE, os, re):
     GWAS_FILE      = _path
     SUMSTATS_FILE  = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
     CTS_FILE       = f"data/{GWAS_STEM}_cell_types.cts"
-    RESULTS_PREFIX = f"results/{GWAS_STEM}_CellTypeSpecific"
+    RESULTS_PREFIX = f"new_results/{GWAS_STEM}_CellTypeSpecific"
 
     print(f"GWAS stem      : {GWAS_STEM}")
     print(f"GWAS file      : {GWAS_FILE}")
@@ -288,42 +288,129 @@ def __(subprocess, os):
 
 @app.cell
 def __(mo):
-    mo.md("## 3. Setup harmonization workflow")
+    mo.md("## 3. Reformat GWAS to harmonizer-compatible format")
+    return
+
+
+@app.cell
+def __(GWAS_FILE, pd, os, glob):
+    import gzip as _gzip
+
+    _lower   = GWAS_FILE.lower()
+    _is_gz   = _lower.endswith(".gz") or _lower.endswith(".bgz")
+    _comp    = "gzip" if _is_gz else None
+    _open_fn = _gzip.open if _is_gz else open
+
+    _skip = 0
+    _peek_line = ""
+    with _open_fn(GWAS_FILE, "rt") as _fh:
+        for _line in _fh:
+            if not _line.startswith("##"):
+                _peek_line = _line
+                break
+    _sep = "\t" if "\t" in _peek_line else " "
+
+    os.makedirs("data/gwas_reformatted", exist_ok=True)
+    REFORMATTED_GWAS = f"data/gwas_reformatted/{os.path.basename(GWAS_FILE)}.gz"
+
+    if os.path.exists(REFORMATTED_GWAS):
+        print(f"Reformatted file already exists: {REFORMATTED_GWAS}")
+    else:
+        _df = pd.read_csv(GWAS_FILE, sep=_sep, compression=_comp, skiprows=_skip)
+        _df.columns = [c.lstrip("#").strip() for c in _df.columns]
+        print(f"  Columns: {list(_df.columns)}")
+
+        _cl = {c.lower(): c for c in _df.columns}
+
+        _snp_col  = _cl.get("markername") or _cl.get("snptestid") or _cl.get("id") or _cl.get("snp") or _cl.get("rsid") or _cl.get("variant_id")
+        _chr_col  = _cl.get("chr") or _cl.get("chrom") or _cl.get("chromosome") or _cl.get("#chrom") or _cl.get("hm_chrom")
+        _pos_col  = _cl.get("pos") or _cl.get("bp") or _cl.get("position") or _cl.get("bp_hg19") or _cl.get("base_pair_location")
+        _a1_col   = _cl.get("a1") or _cl.get("effect_allele") or _cl.get("alt") or _cl.get("hm_effect_allele")
+        _a2_col   = _cl.get("a2") or _cl.get("noneffect_allele") or _cl.get("other_allele") or _cl.get("ref") or _cl.get("hm_other_allele")
+        _beta_col = _cl.get("logor") or _cl.get("log_or") or _cl.get("beta") or _cl.get("b") or _cl.get("hm_beta")
+        _se_col   = _cl.get("se_gc") or _cl.get("stderrlogor") or _cl.get("se") or _cl.get("stderr") or _cl.get("standard_error")
+        _p_col    = _cl.get("p-value_gc") or _cl.get("pvalue") or _cl.get("p_value") or _cl.get("p-value") or _cl.get("p")
+        _n_col    = _cl.get("n_samples") or _cl.get("neff") or _cl.get("n") or _cl.get("n_total")
+
+        _rename = {}
+        if _snp_col:  _rename[_snp_col]  = "snp"
+        if _a1_col:   _rename[_a1_col]   = "a1"
+        if _a2_col:   _rename[_a2_col]   = "a2"
+        if _beta_col: _rename[_beta_col] = "beta"
+        if _se_col:   _rename[_se_col]   = "se"
+        if _p_col:    _rename[_p_col]    = "p"
+        if _n_col:    _rename[_n_col]    = "n"
+        if _chr_col:  _rename[_chr_col]  = "chr"
+        if _pos_col:  _rename[_pos_col]  = "pos"
+        _df = _df.rename(columns=_rename)
+
+        if "chr" not in _df.columns or "pos" not in _df.columns:
+            print("  No chr/pos columns — looking up from bim files via rs IDs...")
+            _bim_map = pd.concat([
+                pd.read_csv(f, sep="\t", header=None, names=["chr","snp","cm","pos","a1b","a2b"])[["snp","chr","pos"]]
+                for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
+            ]).drop_duplicates("snp").set_index("snp")
+            _df["chr"] = _df["snp"].map(_bim_map["chr"])
+            _df["pos"] = _df["snp"].map(_bim_map["pos"])
+            _df = _df.dropna(subset=["chr","pos"])
+            _df["chr"] = _df["chr"].astype(int).astype(str)
+            _df["pos"] = _df["pos"].astype(int).astype(str)
+            print(f"  Mapped {len(_df):,} variants with chr/pos")
+
+        if "chr" in _df.columns:
+            _df["chr"] = _df["chr"].astype(str).str.replace("chr","",regex=False)
+
+        _keep = [c for c in ["chr","pos","snp","a1","a2","beta","se","p","n"] if c in _df.columns]
+        _df[_keep].dropna(subset=["a1","a2","beta","p"]).to_csv(
+            REFORMATTED_GWAS, sep="\t", index=False, compression="gzip"
+        )
+        print(f"  Written {len(_df):,} variants to {REFORMATTED_GWAS}")
+
+    return (REFORMATTED_GWAS,)
+
+
+@app.cell
+def __(mo):
+    mo.md("## 4. Setup harmonization workflow")
     return
 
 
 @app.cell
 def __(os, Path):
-    HARMONIZER_CODE_REPO = os.getenv("HARMONIZER_CODE_REPO", "path/to/harmonizer/repo")
-    HARMONIZER_REF_DIR = os.getenv("HARMONIZER_REF_DIR", "path/to/harmonizer/reference")
+    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/finemapping"
+    HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/finemapping/data/1000Genomes_phase3"
 
-    harmonizer_script = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
+    harmonizer_script = Path(HARMONIZER_CODE_REPO) / "scripts" / "6_harmoniser.sh"
+
+    nextflow_env = {
+        **os.environ,
+        "PATH": "/mnt/hdd_1/rediet/hypothesis-generation-demo:/mnt/hdd_1/rediet/jdk-17/bin:" + os.environ.get("PATH", ""),
+        "JAVA_HOME": "/mnt/hdd_1/rediet/jdk-17",
+    }
 
     if not harmonizer_script.exists():
-        print(f"WARNING: harmonizer.sh not found at {harmonizer_script}")
-        print(f"Please set HARMONIZER_CODE_REPO environment variable")
+        print(f"WARNING: 6_harmoniser.sh not found at {harmonizer_script}")
         harmonizer_ready = False
     elif not os.path.isdir(HARMONIZER_REF_DIR):
-        print(f"WARNING: Harmonizer reference directory not found at {HARMONIZER_REF_DIR}")
-        print(f"Please run harmonizer_setup.sh first or set HARMONIZER_REF_DIR")
+        print(f"WARNING: Reference directory not found at {HARMONIZER_REF_DIR}")
         harmonizer_ready = False
     else:
         print(f"Harmonizer configuration found")
-        print(f"  Code repo: {HARMONIZER_CODE_REPO}")
+        print(f"  Script   : {harmonizer_script}")
         print(f"  Reference: {HARMONIZER_REF_DIR}")
         harmonizer_ready = True
 
-    return (HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, harmonizer_ready)
+    return (HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, harmonizer_ready, harmonizer_script, nextflow_env)
 
 
 @app.cell
 def __(mo):
-    mo.md("## 4. Harmonize GWAS summary statistics")
+    mo.md("## 5. Harmonize GWAS summary statistics")
     return
 
 
 @app.cell
-def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, GWAS_FILE):
+def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DIR, REFORMATTED_GWAS, harmonizer_script, nextflow_env):
     os.makedirs("data/harmonized", exist_ok=True)
 
     harmonized_found = False
@@ -347,13 +434,13 @@ def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DI
         try:
             _result = subprocess.run([
                 "bash",
-                os.path.join(HARMONIZER_CODE_REPO, "harmonizer.sh"),
-                "--input", os.path.abspath(GWAS_FILE),
-                "--build", "GRCh38",
-                "--ref", HARMONIZER_REF_DIR,
+                str(harmonizer_script),
+                "--input",     os.path.abspath(REFORMATTED_GWAS),
+                "--build",     "GRCh38",
+                "--ref",       HARMONIZER_REF_DIR,
                 "--code-repo", HARMONIZER_CODE_REPO,
                 "--threshold", "0.99"
-            ], check=True, capture_output=True, text=True)
+            ], check=True, capture_output=True, text=True, env=nextflow_env)
 
             print(_result.stdout)
             if _result.stderr:
@@ -380,54 +467,69 @@ def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DI
 
 @app.cell
 def __(mo):
-    mo.md("## 5. Convert harmonized output to LDSC format")
+    mo.md("## 6. Convert harmonized output to LDSC format")
     return
 
 
 @app.cell
-def __(os, subprocess, python27_path, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
+def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
     os.makedirs("data/ldsc_input", exist_ok=True)
 
     if harmonized_output_dir is None:
-        print("Skipping LDSC conversion - no harmonized data available")
+        print("Skipping - no harmonized data available")
     elif os.path.exists(SUMSTATS_FILE):
         print(f"LDSC sumstats already exists, skipping: {SUMSTATS_FILE}")
     else:
         _final_dir = os.path.join(harmonized_output_dir, "final")
+        _files = [f for f in os.listdir(_final_dir) if f.endswith(".tsv.gz")] if os.path.exists(_final_dir) else []
 
-        if not os.path.exists(_final_dir):
-            print(f"WARNING: Final directory not found: {_final_dir}")
+        if not _files:
+            print(f"WARNING: No harmonized file found in {_final_dir}")
         else:
-            _harmonized_files = [f for f in os.listdir(_final_dir) if f.endswith(".tsv.gz")]
+            _harmonized_file = os.path.join(_final_dir, _files[0])
+            print(f"Converting {_harmonized_file} to LDSC format...")
 
-            if not _harmonized_files:
-                print(f"WARNING: No .tsv.gz file found in {_final_dir}")
-            else:
-                _harmonized_file = os.path.join(_final_dir, _harmonized_files[0])
-                print(f"Found harmonized file: {_harmonized_file}")
+            _df = pd.read_csv(_harmonized_file, sep="\t", compression="gzip")
+            print(f"  Columns: {list(_df.columns)}")
 
-                _munge_prefix = SUMSTATS_FILE.replace(".sumstats.gz", "")
+            _df = _df.rename(columns={
+                "rsid":            "SNP",
+                "effect_allele":   "A1",
+                "other_allele":    "A2",
+                "beta":            "BETA",
+                "standard_error":  "SE",
+                "p_value":         "P",
+            })
 
-                subprocess.run([
-                    python27_path, "tools/ldsc/munge_sumstats.py",
-                    "--sumstats",        _harmonized_file,
-                    "--out",             _munge_prefix,
-                    "--a1",              "effect_allele",
-                    "--a2",              "other_allele",
-                    "--p",               "p_value",
-                    "--snp",             "rsid",
-                    "--signed-sumstats", "beta,0",
-                    "--merge-alleles",   W_HM3_SNPLIST,
-                ], check=True)
+            _df["BETA"] = pd.to_numeric(_df["BETA"], errors="coerce")
+            _df["SE"]   = pd.to_numeric(_df["SE"],   errors="coerce")
+            _df["A1"]   = _df["A1"].str.upper()
+            _df["A2"]   = _df["A2"].str.upper()
+            _df["Z"]    = _df["BETA"] / _df["SE"]
 
-                print(f"LDSC conversion complete: {SUMSTATS_FILE}")
+            _hm3 = pd.read_csv(W_HM3_SNPLIST, sep="\t")[["SNP", "A1", "A2"]]
+            _df  = _df.merge(_hm3, on="SNP", suffixes=("", "_hm3"))
+            _df  = _df[
+                (_df["A1"] == _df["A1_hm3"]) | (_df["A1"] == _df["A2_hm3"])
+            ].drop(columns=["A1_hm3", "A2_hm3"])
+
+            _strand_ambig = _df.apply(
+                lambda r: set([r["A1"], r["A2"]]) in [{"A","T"}, {"C","G"}], axis=1
+            )
+            _df = _df[~_strand_ambig]
+
+            _keep = [c for c in ["SNP","A1","A2","Z","N"] if c in _df.columns]
+            _out  = _df[_keep].dropna(subset=["SNP","A1","A2","Z"])
+            _out.to_csv(SUMSTATS_FILE, sep="\t", index=False, compression="gzip")
+            print(f"  Written {len(_out):,} SNPs to {SUMSTATS_FILE}")
+            print(f"  Mean |Z|: {_out['Z'].abs().mean():.3f}")
 
     return
 
 
 @app.cell
 def __(mo):
-    mo.md("## 6. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
+    mo.md("## 7. Generate cell-type-specific binary annotations (BED -> .annot.gz)")
     return
 
 
@@ -473,7 +575,7 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
 
 @app.cell
 def __(mo):
-    mo.md("## 7. Calculate LD scores (HapMap3 SNPs only)")
+    mo.md("## 8. Calculate LD scores (HapMap3 SNPs only)")
     return
 
 
@@ -520,13 +622,13 @@ def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessin
 
 @app.cell
 def __(mo):
-    mo.md("## 8. Create CTS reference file")
+    mo.md("## 9. Create CTS reference file")
     return
 
 
 @app.cell
 def __(os, all_cell_types, CTS_FILE):
-    os.makedirs("results", exist_ok=True)
+    os.makedirs("new_results", exist_ok=True)
 
     COMPLETED_CELL_TYPES = []
     for _ct in all_cell_types:
@@ -551,7 +653,7 @@ def __(os, all_cell_types, CTS_FILE):
 
 @app.cell
 def __(mo):
-    mo.md("## 9. Run LDSC cell-type-specific heritability analysis")
+    mo.md("## 10. Run LDSC cell-type-specific heritability analysis")
     return
 
 
@@ -562,7 +664,7 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
     elif not os.path.exists(CTS_FILE):
         print(f"Skipping — CTS file not found: {CTS_FILE}")
     else:
-        os.makedirs("results", exist_ok=True)
+        os.makedirs("new_results", exist_ok=True)
         print("Running LDSC CTS analysis...")
         subprocess.run(
             [
@@ -584,7 +686,7 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
 @app.cell
 def __(mo):
-    mo.md("## 10. Results")
+    mo.md("## 11. Results")
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -39,7 +39,7 @@ def __(mo):
 @app.cell
 def __(mo, os):
     GWAS_INPUT_FILE = mo.ui.text(
-        value="data/gwas/PGC_UKB_depression_genome-wide.txt",
+        value="data/gwas/PASS_AtrialFibrillation_Nielsen2018.sumstats.gz",
         label="GWAS input file path",
         full_width=True,
     )
@@ -47,9 +47,7 @@ def __(mo, os):
     HM3_NO_MHC_LIST = "data/reference/hm3_no_MHC.list.txt"
     CATLAS_DIR       = "humanenhancer_atac_data"
     CATLAS_URL       = "http://catlas.org/humanenhancer/data/cCREs/"
-    BROAD_CELL_TYPES = ["Ast", "Ex", "In", "Microglia", "OPC", "Oligo", "PerEndo"]
-    BROAD_BASE_URL   = "https://personal.broadinstitute.org/bjames/AD_snATAC/major_celltype_matrices/"
-
+  
     mo.vstack([
         mo.md("### Configuration"),
         GWAS_INPUT_FILE,
@@ -60,9 +58,7 @@ def __(mo, os):
         W_HM3_SNPLIST,
         HM3_NO_MHC_LIST,
         CATLAS_DIR,
-        CATLAS_URL,
-        BROAD_CELL_TYPES,
-        BROAD_BASE_URL,
+        CATLAS_URL
     )
 
 
@@ -79,7 +75,7 @@ def __(GWAS_INPUT_FILE, os, re):
     GWAS_FILE      = _path
     SUMSTATS_FILE  = f"data/ldsc_input/{GWAS_STEM}.sumstats.gz"
     CTS_FILE       = f"data/{GWAS_STEM}_cell_types.cts"
-    RESULTS_PREFIX = f"new_results/{GWAS_STEM}_CellTypeSpecific"
+    RESULTS_PREFIX = f"new_results/{GWAS_STEM}_CellTypeSpecific_baseline_v1_weights"
 
     print(f"GWAS stem      : {GWAS_STEM}")
     print(f"GWAS file      : {GWAS_FILE}")
@@ -166,7 +162,7 @@ def __(mo):
 @app.cell
 def __(
     os, urllib, pd, subprocess, re,
-    CATLAS_DIR, CATLAS_URL, BROAD_CELL_TYPES, BROAD_BASE_URL,
+    CATLAS_DIR, CATLAS_URL,
     GWAS_FILE,
 ):
     for _d in ["data/peaks", "data/reference", "data/gwas", "data/beds"]:
@@ -203,8 +199,7 @@ def __(
         bed_out  = f"data/beds/{ct}.bed"
         if os.path.exists(bed_out):
             return bed_out
-        if not os.path.exists(peak_txt):
-            urllib.request.urlretrieve(f"{BROAD_BASE_URL}{ct}.peak.annotation.txt", peak_txt)
+        
         _peaks = pd.read_csv(peak_txt, sep="\t")
         _peaks[["seqnames", "start", "end"]].rename(
             columns={"seqnames": "chr"}
@@ -219,7 +214,7 @@ def __(
             for _f in os.listdir(_sd):
                 if _f.endswith(".bed") and not _f.startswith("."):
                     raw_names.add(os.path.splitext(_f)[0])
-    raw_names.update(BROAD_CELL_TYPES)
+  
 
     cell_type_beds = {}
     _seen = {}
@@ -285,16 +280,15 @@ def __(subprocess, os):
     print("Reference files ready" if os.path.exists(_critical) else f"ERROR: missing {_critical}")
     return
 
-
 @app.cell
 def __(mo):
     mo.md("## 3. Reformat GWAS to harmonizer-compatible format")
     return
 
-
 @app.cell
-def __(GWAS_FILE, pd, os, glob):
+def __(GWAS_FILE, pd, os, glob, SUMSTATS_FILE):
     import gzip as _gzip
+    import shutil as _shutil
 
     _lower   = GWAS_FILE.lower()
     _is_gz   = _lower.endswith(".gz") or _lower.endswith(".bgz")
@@ -313,58 +307,69 @@ def __(GWAS_FILE, pd, os, glob):
     os.makedirs("data/gwas_reformatted", exist_ok=True)
     REFORMATTED_GWAS = f"data/gwas_reformatted/{os.path.basename(GWAS_FILE)}.gz"
 
-    if os.path.exists(REFORMATTED_GWAS):
+    if os.path.exists(SUMSTATS_FILE):
+        print(f"Sumstats already exists, skipping reformat: {SUMSTATS_FILE}")
+    elif os.path.exists(REFORMATTED_GWAS):
         print(f"Reformatted file already exists: {REFORMATTED_GWAS}")
     else:
-        _df = pd.read_csv(GWAS_FILE, sep=_sep, compression=_comp, skiprows=_skip)
+        _df = pd.read_csv(GWAS_FILE, sep=_sep, compression=_comp, skiprows=_skip, low_memory=False)
         _df.columns = [c.lstrip("#").strip() for c in _df.columns]
         print(f"  Columns: {list(_df.columns)}")
 
-        _cl = {c.lower(): c for c in _df.columns}
+        _cl_check = {c.lower() for c in _df.columns}
+        if "z" in _cl_check and "snp" in _cl_check and "beta" not in _cl_check and "logor" not in _cl_check:
+            print("  File is already in LDSC format — copying directly to sumstats")
+            os.makedirs("data/ldsc_input", exist_ok=True)
+            _shutil.copy(GWAS_FILE, SUMSTATS_FILE)
+            print(f"  Copied to {SUMSTATS_FILE}")
+            REFORMATTED_GWAS = GWAS_FILE
+        else:
+            _cl = {c.lower(): c for c in _df.columns}
 
-        _snp_col  = _cl.get("markername") or _cl.get("snptestid") or _cl.get("id") or _cl.get("snp") or _cl.get("rsid") or _cl.get("variant_id")
-        _chr_col  = _cl.get("chr") or _cl.get("chrom") or _cl.get("chromosome") or _cl.get("#chrom") or _cl.get("hm_chrom")
-        _pos_col  = _cl.get("pos") or _cl.get("bp") or _cl.get("position") or _cl.get("bp_hg19") or _cl.get("base_pair_location")
-        _a1_col   = _cl.get("a1") or _cl.get("effect_allele") or _cl.get("alt") or _cl.get("hm_effect_allele")
-        _a2_col   = _cl.get("a2") or _cl.get("noneffect_allele") or _cl.get("other_allele") or _cl.get("ref") or _cl.get("hm_other_allele")
-        _beta_col = _cl.get("logor") or _cl.get("log_or") or _cl.get("beta") or _cl.get("b") or _cl.get("hm_beta")
-        _se_col   = _cl.get("se_gc") or _cl.get("stderrlogor") or _cl.get("se") or _cl.get("stderr") or _cl.get("standard_error")
-        _p_col    = _cl.get("p-value_gc") or _cl.get("pvalue") or _cl.get("p_value") or _cl.get("p-value") or _cl.get("p")
-        _n_col    = _cl.get("n_samples") or _cl.get("neff") or _cl.get("n") or _cl.get("n_total")
+            _snp_col  = _cl.get("markername") or _cl.get("snptestid") or _cl.get("id") or _cl.get("snp") or _cl.get("rsid") or _cl.get("variant_id")
+            _chr_col  = _cl.get("chr") or _cl.get("chrom") or _cl.get("chromosome") or _cl.get("#chrom") or _cl.get("hm_chrom")
+            _pos_col  = _cl.get("pos") or _cl.get("bp") or _cl.get("position") or _cl.get("bp_hg19") or _cl.get("base_pair_location")
+            _a1_col   = _cl.get("a1") or _cl.get("effect_allele") or _cl.get("alt") or _cl.get("hm_effect_allele")
+            _a2_col   = _cl.get("a2") or _cl.get("noneffect_allele") or _cl.get("other_allele") or _cl.get("ref") or _cl.get("hm_other_allele")
+            _beta_col = _cl.get("logor") or _cl.get("log_or") or _cl.get("beta") or _cl.get("b") or _cl.get("hm_beta")
+            _se_col   = _cl.get("se_gc") or _cl.get("stderrlogor") or _cl.get("se") or _cl.get("stderr") or _cl.get("standard_error")
+            _p_col    = _cl.get("p-value_gc") or _cl.get("pvalue") or _cl.get("p_value") or _cl.get("p-value") or _cl.get("p")
+            _n_col    = _cl.get("n_samples") or _cl.get("neff") or _cl.get("n") or _cl.get("n_total")
 
-        _rename = {}
-        if _snp_col:  _rename[_snp_col]  = "snp"
-        if _a1_col:   _rename[_a1_col]   = "a1"
-        if _a2_col:   _rename[_a2_col]   = "a2"
-        if _beta_col: _rename[_beta_col] = "beta"
-        if _se_col:   _rename[_se_col]   = "se"
-        if _p_col:    _rename[_p_col]    = "p"
-        if _n_col:    _rename[_n_col]    = "n"
-        if _chr_col:  _rename[_chr_col]  = "chr"
-        if _pos_col:  _rename[_pos_col]  = "pos"
-        _df = _df.rename(columns=_rename)
+            _rename = {}
+            if _snp_col:  _rename[_snp_col]  = "snp"
+            if _a1_col:   _rename[_a1_col]   = "a1"
+            if _a2_col:   _rename[_a2_col]   = "a2"
+            if _beta_col: _rename[_beta_col] = "beta"
+            if _se_col:   _rename[_se_col]   = "se"
+            if _p_col:    _rename[_p_col]    = "p"
+            if _n_col:    _rename[_n_col]    = "n"
+            if _chr_col:  _rename[_chr_col]  = "chr"
+            if _pos_col:  _rename[_pos_col]  = "pos"
+            _df = _df.rename(columns=_rename)
 
-        if "chr" not in _df.columns or "pos" not in _df.columns:
-            print("  No chr/pos columns — looking up from bim files via rs IDs...")
-            _bim_map = pd.concat([
-                pd.read_csv(f, sep="\t", header=None, names=["chr","snp","cm","pos","a1b","a2b"])[["snp","chr","pos"]]
-                for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
-            ]).drop_duplicates("snp").set_index("snp")
-            _df["chr"] = _df["snp"].map(_bim_map["chr"])
-            _df["pos"] = _df["snp"].map(_bim_map["pos"])
-            _df = _df.dropna(subset=["chr","pos"])
-            _df["chr"] = _df["chr"].astype(int).astype(str)
-            _df["pos"] = _df["pos"].astype(int).astype(str)
-            print(f"  Mapped {len(_df):,} variants with chr/pos")
+            if "chr" not in _df.columns or "pos" not in _df.columns:
+                print("  No chr/pos columns — looking up from bim files via rs IDs...")
+                _bim_map = pd.concat([
+                    pd.read_csv(f, sep="\t", header=None, names=["chr","snp","cm","pos","a1b","a2b"])[["snp","chr","pos"]]
+                    for f in sorted(glob.glob("data/reference/GRCh38/plink_files/1000G.EUR.hg38.*.bim"))
+                ]).drop_duplicates("snp").set_index("snp")
+                _df["chr"] = _df["snp"].map(_bim_map["chr"])
+                _df["pos"] = _df["snp"].map(_bim_map["pos"])
+                _df = _df.dropna(subset=["chr","pos"])
+                _df["chr"] = _df["chr"].astype(int).astype(str)
+                _df["pos"] = _df["pos"].astype(int).astype(str)
+                print(f"  Mapped {len(_df):,} variants with chr/pos")
 
-        if "chr" in _df.columns:
-            _df["chr"] = _df["chr"].astype(str).str.replace("chr","",regex=False)
+            if "chr" in _df.columns:
+                _df["chr"] = _df["chr"].astype(str).str.replace("chr","",regex=False)
 
-        _keep = [c for c in ["chr","pos","snp","a1","a2","beta","se","p","n"] if c in _df.columns]
-        _df[_keep].dropna(subset=["a1","a2","beta","p"]).to_csv(
-            REFORMATTED_GWAS, sep="\t", index=False, compression="gzip"
-        )
-        print(f"  Written {len(_df):,} variants to {REFORMATTED_GWAS}")
+            _keep = [c for c in ["chr","pos","snp","a1","a2","beta","se","p","n"] if c in _df.columns]
+            _dropna_cols = [c for c in ["a1","a2","beta","p"] if c in _df.columns]
+            _df[_keep].dropna(subset=_dropna_cols).to_csv(
+                REFORMATTED_GWAS, sep="\t", index=False, compression="gzip"
+            )
+            print(f"  Written {len(_df):,} variants to {REFORMATTED_GWAS}")
 
     return (REFORMATTED_GWAS,)
 
@@ -377,10 +382,12 @@ def __(mo):
 
 @app.cell
 def __(os, Path):
-    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/finemapping"
-    HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/finemapping/data/1000Genomes_phase3"
+    
+    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser"
+    HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser/data/gwas_harm_ref"
+    harmonizer_script    = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
 
-    harmonizer_script = Path(HARMONIZER_CODE_REPO) / "scripts" / "6_harmoniser.sh"
+
 
     nextflow_env = {
         **os.environ,
@@ -414,6 +421,8 @@ def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DI
     os.makedirs("data/harmonized", exist_ok=True)
 
     harmonized_found = False
+    harmonized_output_dir = None
+
     if os.path.exists("data/harmonized"):
         for item in os.listdir("data/harmonized"):
             if os.path.isdir(os.path.join("data/harmonized", item)):
@@ -423,35 +432,48 @@ def __(subprocess, os, harmonizer_ready, HARMONIZER_CODE_REPO, HARMONIZER_REF_DI
                     harmonized_output_dir = os.path.join("data/harmonized", item)
                     break
 
+    _ssf = os.path.join(
+        os.path.dirname(REFORMATTED_GWAS),
+        os.path.basename(REFORMATTED_GWAS).replace(".gz", ".tsv.gz")
+    )
+    if not harmonized_found and os.path.exists(_ssf):
+        print(f"SSF file exists, skipping harmonization: {_ssf}")
+        harmonized_found = True
+        harmonized_output_dir = "data/harmonized"
+
     if harmonized_found:
         print(f"Harmonized GWAS file already exists: {harmonized_output_dir}")
     elif not harmonizer_ready:
         print("Skipping harmonization - harmonizer not configured")
         harmonized_output_dir = None
     else:
+        os.makedirs("data/harmonized", exist_ok=True)
+        log_file = os.path.abspath(f"data/harmonized/harmonizer_{os.path.basename(REFORMATTED_GWAS)}.log")
+        input_abs = os.path.abspath(REFORMATTED_GWAS)
+
         os.chdir("data/harmonized")
 
         try:
-            _result = subprocess.run([
-                "bash",
-                str(harmonizer_script),
-                "--input",     os.path.abspath(REFORMATTED_GWAS),
-                "--build",     "GRCh38",
-                "--ref",       HARMONIZER_REF_DIR,
-                "--code-repo", HARMONIZER_CODE_REPO,
-                "--threshold", "0.99"
-            ], check=True, capture_output=True, text=True, env=nextflow_env)
+            with open(log_file, "w") as _log:
+                _result = subprocess.run([
+                    "bash",
+                    str(harmonizer_script),
+                    "--input",     input_abs,
+                    "--build",     "GRCh38",
+                    "--ref",       HARMONIZER_REF_DIR,
+                    "--code-repo", HARMONIZER_CODE_REPO,
+                    "--threshold", "0.99"
+                ], check=False, text=True, env=nextflow_env,
+                   stdout=_log, stderr=_log)
 
-            print(_result.stdout)
-            if _result.stderr:
-                print("STDERR:", _result.stderr)
+            print(f"Return code: {_result.returncode}")
+            print(f"Log: {log_file}")
 
             harmonized_dirs = [d for d in os.listdir(".") if os.path.isdir(d)]
             if harmonized_dirs:
                 harmonized_output_dir = os.path.abspath(max(harmonized_dirs))
                 print(f"Harmonization complete: {harmonized_output_dir}")
             else:
-                print("WARNING: No output directory found after harmonization")
                 harmonized_output_dir = None
 
         except subprocess.CalledProcessError as e:
@@ -472,7 +494,7 @@ def __(mo):
 
 
 @app.cell
-def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
+def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST, REFORMATTED_GWAS):
     os.makedirs("data/ldsc_input", exist_ok=True)
 
     if harmonized_output_dir is None:
@@ -484,7 +506,19 @@ def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
         _files = [f for f in os.listdir(_final_dir) if f.endswith(".tsv.gz")] if os.path.exists(_final_dir) else []
 
         if not _files:
-            print(f"WARNING: No harmonized file found in {_final_dir}")
+            print("No final dir — using SSF file directly...")
+            _ssf = os.path.join(
+                os.path.dirname(REFORMATTED_GWAS),
+                os.path.basename(REFORMATTED_GWAS).replace(".gz", ".tsv.gz")
+            )
+            if os.path.exists(_ssf):
+                _files = [os.path.basename(_ssf)]
+                _final_dir = os.path.dirname(_ssf)
+            else:
+                print(f"WARNING: SSF file not found: {_ssf}")
+
+        if not _files:
+            print("WARNING: No harmonized or SSF file found")
         else:
             _harmonized_file = os.path.join(_final_dir, _files[0])
             print(f"Converting {_harmonized_file} to LDSC format...")
@@ -506,6 +540,9 @@ def __(os, pd, harmonized_output_dir, SUMSTATS_FILE, W_HM3_SNPLIST):
             _df["A1"]   = _df["A1"].str.upper()
             _df["A2"]   = _df["A2"].str.upper()
             _df["Z"]    = _df["BETA"] / _df["SE"]
+            if "N" not in _df.columns:
+                print("  No N column found — using study sample size N=807553")
+                _df["N"] = 807553
 
             _hm3 = pd.read_csv(W_HM3_SNPLIST, sep="\t")[["SNP", "A1", "A2"]]
             _df  = _df.merge(_hm3, on="SNP", suffixes=("", "_hm3"))
@@ -645,6 +682,8 @@ def __(os, all_cell_types, CTS_FILE):
 
     with open(CTS_FILE, "w") as _f:
         for _ct in COMPLETED_CELL_TYPES:
+            if _ct == "all_merged_cCREs":
+                continue
             _f.write(f"{_ct}\tdata/ldscores/{_ct}/{_ct}.\n")
 
     print(f"\nCTS file written: {CTS_FILE}  ({len(COMPLETED_CELL_TYPES)} cell types)")
@@ -671,16 +710,16 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
                 python27_path, "tools/ldsc/ldsc.py",
                 "--h2-cts",         SUMSTATS_FILE,
                 "--ref-ld-chr",     (
-                    "data/reference/GRCh38/baselineLD_v2.2/baselineLD.,"
+                    "data/OSF/baseline_v1.2/baseline.,"
                     "data/ldscores/all_merged_cCREs/all_merged_cCREs."
                 ),
                 "--ref-ld-chr-cts", CTS_FILE,
-                "--w-ld-chr",       "data/reference/GRCh38/weights/weights.hm3_noMHC.",
+                "--w-ld-chr",       "data/OSF/weights/weights.hm3_noMHC.",
                 "--out",            RESULTS_PREFIX,
             ],
-            check=True,
+            check=False,
         )
-        print("LDSC CTS analysis complete")
+        print("LDSC CTS analysis complete") 
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -508,62 +508,53 @@ def __(mo):
 
 @app.cell
 def __(subprocess, os, all_cell_types, python27_path):
-    from concurrent.futures import ProcessPoolExecutor
+    import concurrent.futures
     import multiprocessing
 
     os.makedirs("data/ldscores", exist_ok=True)
     HM3_SNP_LIST = "data/reference/hm3_no_MHC.list.txt"
-
     def calculate_single_chrom(args):
-        import os, subprocess
-        ct, chrom, py_path, hm3 = args
+        ct, chrom = args
         out_dir = f"data/ldscores/{ct}"
         os.makedirs(out_dir, exist_ok=True)
-
+        
         ldscore_file = f"{out_dir}/{ct}.{chrom}.l2.ldscore.gz"
         if os.path.exists(ldscore_file):
-            return f"[{ct}] Chr {chrom} skipped (exists)"
+            return f"[{ct}] Chr {chrom} already exists. Skipping."
 
         try:
             subprocess.run([
-                py_path, "tools/ldsc/ldsc.py",
+                python27_path, "tools/ldsc/ldsc.py",
                 "--l2",
                 "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{chrom}",
                 "--ld-wind-cm", "1.0",
                 "--annot",      f"data/annotations/{ct}.{chrom}.annot.gz",
                 "--thin-annot",
-                "--print-snps", hm3,
+                "--print-snps", HM3_SNP_LIST,
                 "--out",        f"{out_dir}/{ct}.{chrom}"
             ], check=True, capture_output=True)
-            return f"[{ct}] Chr {chrom} done"
-        except subprocess.CalledProcessError as e:
-            return f"ERROR [{ct}] Chr {chrom}: {e.stderr[:200]}"
-
-    tasks = [
-        (ct, chrom, python27_path, HM3_SNP_LIST)
-        for ct in all_cell_types
-        for chrom in range(1, 23)
-        if not os.path.exists(f"data/ldscores/{ct}/{ct}.{chrom}.l2.ldscore.gz")
-    ]
-
-    print(f"{len(tasks)} chromosome-level tasks remaining")
-
-    if tasks:
-        max_workers = min(multiprocessing.cpu_count() - 2, 22)
-        print(f"Running with {max_workers} workers...")
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
-            for result in executor.map(calculate_single_chrom, tasks):
-                print(result)
+            return f"[{ct}] Chr {chrom} calculation complete."
+        except subprocess.CalledProcessError as e: 
+            return f"ERROR on [{ct}] Chr {chrom}: {e.stderr}"
+    tasks = []
+    for ct in all_cell_types:
+        for chrom in range(1, 23):
+            tasks.append((ct, chrom))
+    max_workers = min(multiprocessing.cpu_count() - 1, 6)
+    
+    print(f"Starting parallel LDSC calculation with {max_workers} workers...")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for result in executor.map(calculate_single_chrom, tasks):
+            print(result)
 
     print("\nAll LD scores calculated using HapMap3 SNPs")
     return
 
 
 
-
 @app.cell
 def __(mo):
-    mo.md("## 7. Create CTS (cell-type–specific) reference file") 
+    mo.md("## 7. Create CTS (cell-type–specific) reference file")
     return
 
 
@@ -610,8 +601,7 @@ def __(cts_path, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
 
     else:
         os.makedirs("results", exist_ok=True)
-
-        print("Running LDSC cell-type–specific heritability analysis (single run)...")
+        print("Running LDSC cell-type–specific heritability analysis...")
 
         subprocess.run([
             python27_path, "tools/ldsc/ldsc.py",

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -37,15 +37,16 @@ def __(mo):
 
 
 @app.cell
-def __(mo, os):
-    GWAS_INPUT_FILE = mo.ui.text(
-        value="data/gwas/PASS_AtrialFibrillation_Nielsen2018.sumstats.gz",
+def __(mo):
+    S3_BASE          = "s3://rejuve-bio/hypothesis-generation-demo"
+    GWAS_INPUT_FILE  = mo.ui.text(
+        value=f"{S3_BASE}/data/gwas/PASS_AtrialFibrillation_Nielsen2018.sumstats.gz",
         label="GWAS input file path",
         full_width=True,
     )
-    W_HM3_SNPLIST   = "/mnt/hdd_1/rediet/hypothesis-generation-demo/ldsc/data/w_hm3.snplist"
-    HM3_NO_MHC_LIST = "data/reference/hm3_no_MHC.list.txt"
-    CATLAS_DIR       = "humanenhancer_atac_data"
+    W_HM3_SNPLIST   = f"{S3_BASE}/ldsc/data/w_hm3.snplist"
+    HM3_NO_MHC_LIST = f"{S3_BASE}/data/reference/hm3_no_MHC.list.txt"
+    CATLAS_DIR       = f"{S3_BASE}/humanenhancer_atac_data"
     CATLAS_URL       = "http://catlas.org/humanenhancer/data/cCREs/"
 
     mo.vstack([
@@ -54,11 +55,12 @@ def __(mo, os):
         mo.md(f"w_hm3.snplist: `{W_HM3_SNPLIST}`"),
     ])
     return (
+        S3_BASE,
         GWAS_INPUT_FILE,
         W_HM3_SNPLIST,
         HM3_NO_MHC_LIST,
         CATLAS_DIR,
-        CATLAS_URL
+        CATLAS_URL,
     )
 
 
@@ -89,6 +91,7 @@ def __(GWAS_INPUT_FILE, os, re):
         RESULTS_PREFIX,
     )
 
+
 @app.cell
 def __(mo):
     mo.md("## 0. Setup: download and configure LDSC")
@@ -96,19 +99,54 @@ def __(mo):
 
 
 @app.cell
-def __(Path, subprocess, os):
-    import json as _json
-
+def __(Path, subprocess, os, json):
     TOOLS_DIR = Path("tools")
     LDSC_DIR  = TOOLS_DIR / "ldsc"
+    TOOLS_DIR.mkdir(exist_ok=True)
 
-    subprocess.run(["chmod", "+x", str(LDSC_DIR / "ldsc.py")], check=True)
+    _env_check = subprocess.run(["conda", "env", "list"], capture_output=True, text=True)
+    if "ldsc27" not in _env_check.stdout:
+        subprocess.run(["conda", "create", "-n", "ldsc27", "python=2.7", "-y"], check=True)
 
     _conda_json = subprocess.run(
         ["conda", "env", "list", "--json"], capture_output=True, text=True, check=True
     )
-    _envs = _json.loads(_conda_json.stdout)["envs"]
+    _envs = json.loads(_conda_json.stdout)["envs"]
     ldsc27_path = [e for e in _envs if "ldsc27" in e][0]
+
+    if not os.path.exists(os.path.join(ldsc27_path, "bin", "bedtools")):
+        subprocess.run(
+            ["conda", "install", "-n", "ldsc27", "-c", "bioconda", "bedtools", "-y"],
+            check=True,
+        )
+
+    if not LDSC_DIR.exists():
+        subprocess.run(
+            ["git", "clone", "https://github.com/bulik/ldsc.git", str(LDSC_DIR)],
+            check=True,
+        )
+
+    _check_np = subprocess.run(
+        [os.path.join(ldsc27_path, "bin", "python"), "-c", "import numpy"],
+        capture_output=True,
+    )
+    if _check_np.returncode != 0:
+        subprocess.run(
+            ["conda", "install", "-n", "ldsc27", "-y", "openssl=1.0.2", "-c", "conda-forge"],
+            check=True,
+        )
+        subprocess.run(
+            ["conda", "install", "-n", "ldsc27", "-y",
+             "numpy", "scipy", "pandas", "bitarray", "-c", "conda-forge"],
+            check=True,
+        )
+        subprocess.run(
+            ["conda", "install", "-n", "ldsc27", "-y",
+             "pybedtools", "pysam=0.15.3", "-c", "bioconda", "-c", "conda-forge"],
+            check=True,
+        )
+
+    subprocess.run(["chmod", "+x", str(LDSC_DIR / "ldsc.py")], check=True)
     python27_path = os.path.join(ldsc27_path, "bin", "python")
 
     print(f"LDSC environment ready")
@@ -126,7 +164,7 @@ def __(mo):
 @app.cell
 def __(
     os, urllib, pd, subprocess, re,
-    CATLAS_DIR, CATLAS_URL,
+    S3_BASE, CATLAS_DIR, CATLAS_URL,
     GWAS_FILE,
 ):
     for _d in ["data/peaks", "data/reference", "data/gwas", "data/beds"]:
@@ -159,11 +197,10 @@ def __(
         return None
 
     def _peak_to_bed(ct):
-        peak_txt = f"data/peaks/{ct}.peak.annotation.txt"
+        peak_txt = f"{S3_BASE}/data/peaks/{ct}.peak.annotation.txt"
         bed_out  = f"data/beds/{ct}.bed"
         if os.path.exists(bed_out):
             return bed_out
-
         _peaks = pd.read_csv(peak_txt, sep="\t")
         _peaks[["seqnames", "start", "end"]].rename(
             columns={"seqnames": "chr"}
@@ -217,7 +254,7 @@ def __(mo):
 
 
 @app.cell
-def __(subprocess, os):
+def __(subprocess, os, S3_BASE):
     if not os.path.exists("data/reference/GRCh38"):
         subprocess.run(
             ["tar", "-xzf", "data/reference/GRCh38.tgz", "-C", "data/reference"],
@@ -226,12 +263,12 @@ def __(subprocess, os):
 
     for _tgz, _base, _check in [
         (
-            "data/reference/GRCh38/plink_files.tgz",
+            f"{S3_BASE}/data/reference/GRCh38/plink_files.tgz",
             "data/reference/GRCh38",
             "plink_files/1000G.EUR.hg38.1.bim",
         ),
         (
-            "data/reference/GRCh38/weights.tgz",
+            f"{S3_BASE}/data/reference/GRCh38/weights.tgz",
             "data/reference/GRCh38",
             "weights",
         ),
@@ -571,7 +608,7 @@ def __(mo):
 
 
 @app.cell
-def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_path):
+def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_path, S3_BASE):
     os.makedirs("data/annotations", exist_ok=True)
     _env = os.environ.copy()
     _env["PATH"] = f"{ldsc27_path}/bin:" + _env.get("PATH", "")
@@ -595,7 +632,7 @@ def __(subprocess, os, all_cell_types, cell_type_beds, python27_path, ldsc27_pat
                 [
                     python27_path, "tools/ldsc/make_annot.py",
                     "--bed-file",   _bed,
-                    "--bimfile",    f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_ch}.bim",
+                    "--bimfile",    f"{S3_BASE}/data/reference/GRCh38/plink_files/1000G.EUR.hg38.{_ch}.bim",
                     "--annot-file", _out,
                 ],
                 capture_output=True, text=True, env=_env,
@@ -617,7 +654,7 @@ def __(mo):
 
 
 @app.cell
-def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessing, HM3_NO_MHC_LIST):
+def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessing, HM3_NO_MHC_LIST, S3_BASE):
     os.makedirs("data/ldscores", exist_ok=True)
 
     def _calc_ld(args):
@@ -632,7 +669,7 @@ def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessin
                 [
                     python27_path, "tools/ldsc/ldsc.py",
                     "--l2",
-                    "--bfile",      f"data/reference/GRCh38/plink_files/1000G.EUR.hg38.{ch}",
+                    "--bfile",      f"{S3_BASE}/data/reference/GRCh38/plink_files/1000G.EUR.hg38.{ch}",
                     "--ld-wind-cm", "1.0",
                     "--annot",      f"data/annotations/{ct}.{ch}.annot.gz",
                     "--thin-annot",
@@ -697,7 +734,7 @@ def __(mo):
 
 
 @app.cell
-def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
+def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess, S3_BASE):
     if not os.path.exists(SUMSTATS_FILE):
         print(f"Skipping — sumstats not found: {SUMSTATS_FILE}")
     elif not os.path.exists(CTS_FILE):
@@ -710,11 +747,11 @@ def __(CTS_FILE, python27_path, SUMSTATS_FILE, RESULTS_PREFIX, os, subprocess):
                 python27_path, "tools/ldsc/ldsc.py",
                 "--h2-cts",         SUMSTATS_FILE,
                 "--ref-ld-chr",     (
-                    "data/OSF/baseline_v1.2/baseline.,"
+                    f"{S3_BASE}/data/OSF/baseline_v1.2/baseline.,"
                     "data/ldscores/all_merged_cCREs/all_merged_cCREs."
                 ),
                 "--ref-ld-chr-cts", CTS_FILE,
-                "--w-ld-chr",       "data/OSF/weights/weights.hm3_noMHC.",
+                "--w-ld-chr",       f"{S3_BASE}/data/OSF/weights/weights.hm3_noMHC.",
                 "--out",            RESULTS_PREFIX,
             ],
             check=False,

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -89,7 +89,6 @@ def __(GWAS_INPUT_FILE, os, re):
         RESULTS_PREFIX,
     )
 
-
 @app.cell
 def __(mo):
     mo.md("## 0. Setup: download and configure LDSC")
@@ -102,15 +101,6 @@ def __(Path, subprocess, os):
 
     TOOLS_DIR = Path("tools")
     LDSC_DIR  = TOOLS_DIR / "ldsc"
-    TOOLS_DIR.mkdir(exist_ok=True)
-
-    subprocess.run(["uv", "add", "statsmodels", "pyyaml"], check=False)
-
-    if not LDSC_DIR.exists():
-        subprocess.run(
-            ["git", "clone", "https://github.com/bulik/ldsc.git", str(LDSC_DIR)],
-            check=True,
-        )
 
     subprocess.run(["chmod", "+x", str(LDSC_DIR / "ldsc.py")], check=True)
 
@@ -129,7 +119,7 @@ def __(Path, subprocess, os):
 
 @app.cell
 def __(mo):
-    mo.md("## 1. Download cell-type peak annotations and reference files")
+    mo.md("## 1. Discover cell types and resolve BED sources")
     return
 
 
@@ -357,12 +347,7 @@ def __(mo):
 
 @app.cell
 def __(os, Path):
-    HARMONIZER_CODE_REPO = "/mnt/hdd_1/
-    
-    
-    
-    
-    /gwas-sumstats-harmoniser"
+    HARMONIZER_CODE_REPO = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser"
     HARMONIZER_REF_DIR   = "/mnt/hdd_1/abdu/gwas-sumstats-harmoniser/data/gwas_harm_ref"
     harmonizer_script    = Path(HARMONIZER_CODE_REPO) / "harmonizer.sh"
 
@@ -668,7 +653,7 @@ def __(subprocess, os, all_cell_types, python27_path, concurrent, multiprocessin
         for _res in _ex.map(_calc_ld, _tasks):
             print(_res)
 
-    print("\nAll LD scores calculated using HapMap3 SNPs")
+    print("\nAll LD scores calculated")
     return
 
 

--- a/notebooks/AD_regulome_analysis_notebook.py
+++ b/notebooks/AD_regulome_analysis_notebook.py
@@ -97,26 +97,14 @@ def __(mo):
 
 
 @app.cell
-def __(Path, subprocess, os, json):
+def __(Path, subprocess, os):
+    import json as _json
+
     TOOLS_DIR = Path("tools")
     LDSC_DIR  = TOOLS_DIR / "ldsc"
     TOOLS_DIR.mkdir(exist_ok=True)
 
-    _env_check = subprocess.run(["conda", "env", "list"], capture_output=True, text=True)
-    if "ldsc27" not in _env_check.stdout:
-        subprocess.run(["conda", "create", "-n", "ldsc27", "python=2.7", "-y"], check=True)
-
-    _conda_json = subprocess.run(
-        ["conda", "env", "list", "--json"], capture_output=True, text=True, check=True
-    )
-    _envs = json.loads(_conda_json.stdout)["envs"]
-    ldsc27_path = [e for e in _envs if "ldsc27" in e][0]
-
-    if not os.path.exists(os.path.join(ldsc27_path, "bin", "bedtools")):
-        subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-c", "bioconda", "bedtools", "-y"],
-            check=True,
-        )
+    subprocess.run(["uv", "add", "statsmodels", "pyyaml"], check=False)
 
     if not LDSC_DIR.exists():
         subprocess.run(
@@ -124,27 +112,13 @@ def __(Path, subprocess, os, json):
             check=True,
         )
 
-    _check_np = subprocess.run(
-        [os.path.join(ldsc27_path, "bin", "python"), "-c", "import numpy"],
-        capture_output=True,
-    )
-    if _check_np.returncode != 0:
-        subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-y", "openssl=1.0.2", "-c", "conda-forge"],
-            check=True,
-        )
-        subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-y",
-             "numpy", "scipy", "pandas", "bitarray", "-c", "conda-forge"],
-            check=True,
-        )
-        subprocess.run(
-            ["conda", "install", "-n", "ldsc27", "-y",
-             "pybedtools", "pysam=0.15.3", "-c", "bioconda", "-c", "conda-forge"],
-            check=True,
-        )
-
     subprocess.run(["chmod", "+x", str(LDSC_DIR / "ldsc.py")], check=True)
+
+    _conda_json = subprocess.run(
+        ["conda", "env", "list", "--json"], capture_output=True, text=True, check=True
+    )
+    _envs = _json.loads(_conda_json.stdout)["envs"]
+    ldsc27_path = [e for e in _envs if "ldsc27" in e][0]
     python27_path = os.path.join(ldsc27_path, "bin", "python")
 
     print(f"LDSC environment ready")

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3777 @@
+version = 1
+revision = 3
+requires-python = "==3.10.*"
+
+[[package]]
+name = "adjusttext"
+version = "0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/fc/1ed0d0302c80f7238cb4169d4a505aa3594ca2acffbeb1680aaed136a923/adjustText-0.8.tar.gz", hash = "sha256:bb0682bb53abb626d6afc9c1db108ccb67f2c35ddc8d20ac6a802c756c07ee17", size = 10085, upload-time = "2023-02-17T10:54:27.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/36/ac4a2dfefe115be67403bb8c622edf5b6adacbb3afd2ac921af37138ec1c/adjustText-0.8-py3-none-any.whl", hash = "sha256:6da99f9d739c496f79346753a3fcadb6354d8d09699cde112fed46cfb837d271", size = 9132, upload-time = "2023-02-17T10:54:26.116Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "async-timeout" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ce/3b83ebba6b3207a7135e5fcaba49706f8a4b6008153b4e30540c982fae26/aiohttp-3.13.2.tar.gz", hash = "sha256:40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca", size = 7837994, upload-time = "2025-10-28T20:59:39.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/34/939730e66b716b76046dedfe0842995842fa906ccc4964bba414ff69e429/aiohttp-3.13.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2372b15a5f62ed37789a6b383ff7344fc5b9f243999b0cd9b629d8bc5f5b4155", size = 736471, upload-time = "2025-10-28T20:55:27.924Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/dcbdf2df7f6ca72b0bb4c0b4509701f2d8942cf54e29ca197389c214c07f/aiohttp-3.13.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7f8659a48995edee7229522984bd1009c1213929c769c2daa80b40fe49a180c", size = 493985, upload-time = "2025-10-28T20:55:29.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/87/71c8867e0a1d0882dcbc94af767784c3cb381c1c4db0943ab4aae4fed65e/aiohttp-3.13.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:939ced4a7add92296b0ad38892ce62b98c619288a081170695c6babe4f50e636", size = 489274, upload-time = "2025-10-28T20:55:31.134Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0f/46c24e8dae237295eaadd113edd56dee96ef6462adf19b88592d44891dc5/aiohttp-3.13.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6315fb6977f1d0dd41a107c527fee2ed5ab0550b7d885bc15fee20ccb17891da", size = 1668171, upload-time = "2025-10-28T20:55:36.065Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c6/4cdfb4440d0e28483681a48f69841fa5e39366347d66ef808cbdadddb20e/aiohttp-3.13.2-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6e7352512f763f760baaed2637055c49134fd1d35b37c2dedfac35bfe5cf8725", size = 1636036, upload-time = "2025-10-28T20:55:37.576Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/8708cf678628216fb678ab327a4e1711c576d6673998f4f43e86e9ae90dd/aiohttp-3.13.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e09a0a06348a2dd73e7213353c90d709502d9786219f69b731f6caa0efeb46f5", size = 1727975, upload-time = "2025-10-28T20:55:39.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2e/3ebfe12fdcb9b5f66e8a0a42dffcd7636844c8a018f261efb2419f68220b/aiohttp-3.13.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a09a6d073fb5789456545bdee2474d14395792faa0527887f2f4ec1a486a59d3", size = 1815823, upload-time = "2025-10-28T20:55:40.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/ca2ef819488cbb41844c6cf92ca6dd15b9441e6207c58e5ae0e0fc8d70ad/aiohttp-3.13.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b59d13c443f8e049d9e94099c7e412e34610f1f49be0f230ec656a10692a5802", size = 1669374, upload-time = "2025-10-28T20:55:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fe/1fe2e1179a0d91ce09c99069684aab619bf2ccde9b20bd6ca44f8837203e/aiohttp-3.13.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:20db2d67985d71ca033443a1ba2001c4b5693fe09b0e29f6d9358a99d4d62a8a", size = 1555315, upload-time = "2025-10-28T20:55:44.264Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2b/f3781899b81c45d7cbc7140cddb8a3481c195e7cbff8e36374759d2ab5a5/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:960c2fc686ba27b535f9fd2b52d87ecd7e4fd1cf877f6a5cba8afb5b4a8bd204", size = 1639140, upload-time = "2025-10-28T20:55:46.626Z" },
+    { url = "https://files.pythonhosted.org/packages/72/27/c37e85cd3ece6f6c772e549bd5a253d0c122557b25855fb274224811e4f2/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:6c00dbcf5f0d88796151e264a8eab23de2997c9303dd7c0bf622e23b24d3ce22", size = 1645496, upload-time = "2025-10-28T20:55:48.933Z" },
+    { url = "https://files.pythonhosted.org/packages/66/20/3af1ab663151bd3780b123e907761cdb86ec2c4e44b2d9b195ebc91fbe37/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fed38a5edb7945f4d1bcabe2fcd05db4f6ec7e0e82560088b754f7e08d93772d", size = 1697625, upload-time = "2025-10-28T20:55:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/95/eb/ae5cab15efa365e13d56b31b0d085a62600298bf398a7986f8388f73b598/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:b395bbca716c38bef3c764f187860e88c724b342c26275bc03e906142fc5964f", size = 1542025, upload-time = "2025-10-28T20:55:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2d/1683e8d67ec72d911397fe4e575688d2a9b8f6a6e03c8fdc9f3fd3d4c03f/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:204ffff2426c25dfda401ba08da85f9c59525cdc42bda26660463dd1cbcfec6f", size = 1714918, upload-time = "2025-10-28T20:55:53.515Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ffe8e0e1c57c5e542d47ffa1fcf95ef2b3ea573bf7c4d2ee877252431efc/aiohttp-3.13.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:05c4dd3c48fb5f15db31f57eb35374cb0c09afdde532e7fb70a75aede0ed30f6", size = 1656113, upload-time = "2025-10-28T20:55:55.438Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/d511aff5c3a2b06c09d7d214f508a4ad8ac7799817f7c3d23e7336b5e896/aiohttp-3.13.2-cp310-cp310-win32.whl", hash = "sha256:e574a7d61cf10351d734bcddabbe15ede0eaa8a02070d85446875dc11189a251", size = 432290, upload-time = "2025-10-28T20:55:56.96Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ea/1c2eb7098b5bad4532994f2b7a8228d27674035c9b3234fe02c37469ef14/aiohttp-3.13.2-cp310-cp310-win_amd64.whl", hash = "sha256:364f55663085d658b8462a1c3f17b2b84a5c2e1ba858e1b79bff7b2e24ad1514", size = 455075, upload-time = "2025-10-28T20:55:58.373Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/b6/2a81d7724c0c124edc5ec7a167e85858b6fd31b9611c6fb8ecf617b7e2d3/alembic-1.17.1.tar.gz", hash = "sha256:8a289f6778262df31571d29cca4c7fbacd2f0f582ea0816f4c399b6da7528486", size = 1981285, upload-time = "2025-10-29T00:23:16.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/32/7df1d81ec2e50fb661944a35183d87e62d3f6c6d9f8aff64a4f245226d55/alembic-1.17.1-py3-none-any.whl", hash = "sha256:cbc2386e60f89608bb63f30d2d6cc66c7aaed1fe105bd862828600e5ad167023", size = 247848, upload-time = "2025-10-29T00:23:18.79Z" },
+]
+
+[[package]]
+name = "aniso8601"
+version = "10.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/52179c4e3f1978d3d9a285f98c706642522750ef343e9738286130423730/aniso8601-10.0.1.tar.gz", hash = "sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845", size = 47190, upload-time = "2025-04-18T17:29:42.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/75/e0e10dc7ed1408c28e03a6cb2d7a407f99320eb953f229d008a7a6d05546/aniso8601-10.0.1-py2.py3-none-any.whl", hash = "sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e", size = 52848, upload-time = "2025-04-18T17:29:41.492Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/a6/dc46877b911e40c00d395771ea710d5e77b6de7bacd5fdcd78d70cc5a48f/annotated_doc-0.0.3.tar.gz", hash = "sha256:e18370014c70187422c33e945053ff4c286f453a984eba84d0dbfa0c935adeda", size = 5535, upload-time = "2025-10-24T14:57:10.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/b7/cf592cb5de5cb3bade3357f8d2cf42bf103bbe39f459824b4939fd212911/annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580", size = 5488, upload-time = "2025-10-24T14:57:09.462Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/07/61f3ca8e69c5dcdaec31b36b79a53ea21c5b4ca5e93c7df58c71f43bf8d8/anthropic-0.72.0.tar.gz", hash = "sha256:8971fe76dcffc644f74ac3883069beb1527641115ae0d6eb8fa21c1ce4082f7a", size = 493721, upload-time = "2025-10-28T19:13:01.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/b7/160d4fb30080395b4143f1d1a4f6c646ba9105561108d2a434b606c03579/anthropic-0.72.0-py3-none-any.whl", hash = "sha256:0e9f5a7582f038cab8efbb4c959e49ef654a56bfc7ba2da51b5a7b8a84de2e4d", size = 357464, upload-time = "2025-10-28T19:13:00.215Z" },
+]
+
+[package.optional-dependencies]
+bedrock = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
+vertex = [
+    { name = "google-auth", extra = ["requests"] },
+]
+
+[[package]]
+name = "anyio"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
+
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
+name = "apprise"
+version = "1.9.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "click" },
+    { name = "markdown" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/16/e39338b8310af9466fab6f4482b542e24cb1fcbb7e36bf00c089c4e015e7/apprise-1.9.5.tar.gz", hash = "sha256:8f3be318bb429c2017470e33928a2e313cbf7600fc74b8184782a37060db366a", size = 1877134, upload-time = "2025-09-30T15:57:28.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/f1/318762320d966e528dfb9e6be5953fe7df2952156f15ba857cbccafb630c/apprise-1.9.5-py3-none-any.whl", hash = "sha256:1873a8a1b8cf9e44fcbefe0486ed260b590652aea12427f545b37c8566142961", size = 1421011, upload-time = "2025-09-30T15:57:26.268Z" },
+]
+
+[[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/da/e7908b54e0f8043725a990bf625f2041ecf6bfe8eb7b19407f1c00b630f7/asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308", size = 15627, upload-time = "2023-03-28T17:35:49.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f", size = 10895, upload-time = "2023-03-28T17:35:47.772Z" },
+]
+
+[[package]]
+name = "astroid"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/d1/6eee8726a863f28ff50d26c5eacb1a590f96ccbb273ce0a8c047ffb10f5a/astroid-4.0.1.tar.gz", hash = "sha256:0d778ec0def05b935e198412e62f9bcca8b3b5c39fdbe50b0ba074005e477aab", size = 405414, upload-time = "2025-10-11T15:15:42.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/f4/034361a9cbd9284ef40c8ad107955ede4efae29cbc17a059f63f6569c06a/astroid-4.0.1-py3-none-any.whl", hash = "sha256:37ab2f107d14dc173412327febf6c78d39590fdafcb44868f03b6c03452e3db0", size = 276268, upload-time = "2025-10-11T15:15:40.585Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/4c/7c991e080e106d854809030d8584e15b2e996e26f16aee6d757e387bc17d/asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851", size = 957746, upload-time = "2024-10-20T00:30:41.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/07/1650a8c30e3a5c625478fa8aafd89a8dd7d85999bf7169b16f54973ebf2c/asyncpg-0.30.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfb4dd5ae0699bad2b233672c8fc5ccbd9ad24b89afded02341786887e37927e", size = 673143, upload-time = "2024-10-20T00:29:08.846Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9a/568ff9b590d0954553c56806766914c149609b828c426c5118d4869111d3/asyncpg-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc1f62c792752a49f88b7e6f774c26077091b44caceb1983509edc18a2222ec0", size = 645035, upload-time = "2024-10-20T00:29:12.02Z" },
+    { url = "https://files.pythonhosted.org/packages/de/11/6f2fa6c902f341ca10403743701ea952bca896fc5b07cc1f4705d2bb0593/asyncpg-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3152fef2e265c9c24eec4ee3d22b4f4d2703d30614b0b6753e9ed4115c8a146f", size = 2912384, upload-time = "2024-10-20T00:29:13.644Z" },
+    { url = "https://files.pythonhosted.org/packages/83/83/44bd393919c504ffe4a82d0aed8ea0e55eb1571a1dea6a4922b723f0a03b/asyncpg-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7255812ac85099a0e1ffb81b10dc477b9973345793776b128a23e60148dd1af", size = 2947526, upload-time = "2024-10-20T00:29:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/08/85/e23dd3a2b55536eb0ded80c457b0693352262dc70426ef4d4a6fc994fa51/asyncpg-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:578445f09f45d1ad7abddbff2a3c7f7c291738fdae0abffbeb737d3fc3ab8b75", size = 2895390, upload-time = "2024-10-20T00:29:19.346Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/fa96c8f4877d47dc6c1864fef5500b446522365da3d3d0ee89a5cce71a3f/asyncpg-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c42f6bb65a277ce4d93f3fba46b91a265631c8df7250592dd4f11f8b0152150f", size = 3015630, upload-time = "2024-10-20T00:29:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/34/00/814514eb9287614188a5179a8b6e588a3611ca47d41937af0f3a844b1b4b/asyncpg-0.30.0-cp310-cp310-win32.whl", hash = "sha256:aa403147d3e07a267ada2ae34dfc9324e67ccc4cdca35261c8c22792ba2b10cf", size = 568760, upload-time = "2024-10-20T00:29:22.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/28/869a7a279400f8b06dd237266fdd7220bc5f7c975348fea5d1e6909588e9/asyncpg-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb622c94db4e13137c4c7f98834185049cc50ee01d8f657ef898b6407c7b9c50", size = 625764, upload-time = "2024-10-20T00:29:25.882Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "banks"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "griffe" },
+    { name = "jinja2" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f8/25ef24814f77f3fd7f0fd3bd1ef3749e38a9dbd23502fbb53034de49900c/banks-2.2.0.tar.gz", hash = "sha256:d1446280ce6e00301e3e952dd754fd8cee23ff277d29ed160994a84d0d7ffe62", size = 179052, upload-time = "2025-07-18T16:28:26.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/d6/f9168956276934162ec8d48232f9920f2985ee45aa7602e3c6b4bc203613/banks-2.2.0-py3-none-any.whl", hash = "sha256:963cd5c85a587b122abde4f4064078def35c50c688c1b9d36f43c92503854e7d", size = 29244, upload-time = "2025-07-18T16:28:27.835Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
+name = "biopython"
+version = "1.86"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/c59a849bd457c8a1b408ae828dbcc15e674962b5a29705e869e15b32bf25/biopython-1.86.tar.gz", hash = "sha256:93a50b586a4d2cec68ab2f99d03ef583c5761d8fba5535cb8e81da781d0d92ff", size = 19835323, upload-time = "2025-10-28T21:18:31.041Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/9f/5c95732ad98a6d40f4be58978be801cc87b50c71d79a7aee46c4a085114d/biopython-1.86-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:02aef2e31cc92544f574ff837cabaaaf53733f3a6b5a433f781c59e5424a7576", size = 2691935, upload-time = "2025-10-28T21:27:12.558Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/15/9902cbc901073ba2de397f5c9c84e72147e02aaca1755fa650d26bb715a2/biopython-1.86-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e1b12819a78242b529f54e5d2d00ad90023710a5846ca0f2011ac989fd17d4b", size = 2669420, upload-time = "2025-10-28T21:26:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5d/9cb775106361f8ef7ab459b89ff6d725e81dae7abd382309d3bbf82ced6d/biopython-1.86-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e62504faac6e62fe26e40d6905a69519d8b7b5b0506a426d641b218fde788b5", size = 3183554, upload-time = "2025-10-29T00:35:24.074Z" },
+    { url = "https://files.pythonhosted.org/packages/08/47/87c8db55746099b38baf6c597688807bad2e59074cec37169168fe98e69e/biopython-1.86-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d4530060aadc6af060a9a049da91a582738837e187fcea80486c71eca74ae59", size = 3205260, upload-time = "2025-10-29T00:35:33.89Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/7822f6b7521073ccc80eb18736b664efe1d59edeb6a3f72c362f542ec352/biopython-1.86-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:186e2065c0d1a6c2afc85b9c21a2911a931949668bd73b4c03f429a31b3589f8", size = 3154783, upload-time = "2025-10-28T23:52:52.157Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7a/6759f99b481432969a4979f03b4c4966716d4cffd2154749ae5af0d8904a/biopython-1.86-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6915a09859159598b9421e7240561692e7bb4084e5340c4dbb2435c5c38805a2", size = 3173920, upload-time = "2025-10-28T23:52:57.611Z" },
+    { url = "https://files.pythonhosted.org/packages/17/c2/fe2a223b3fdd718099055679b68f9f15b2006d83a5a1c1593246d5e5fe81/biopython-1.86-cp310-cp310-win32.whl", hash = "sha256:be3d83152fe3232e2d197896a506902b84ad60d40b3f1d1fc934914d138c6dc1", size = 2697949, upload-time = "2025-10-28T21:32:07.305Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/11/44fb3975df1070966ffc213f52e9fff63fb48b43bc3d403584ca3f4f9a42/biopython-1.86-cp310-cp310-win_amd64.whl", hash = "sha256:6fbbfe19e12170754adb9632155b7e3be0d4c247f0a2e09d3917bec859282de1", size = 2734235, upload-time = "2025-10-28T21:32:03.014Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/04/619bf4f1191021aa54514a3da4fbe91f7a04bf827fad0c1d562f8b3db474/boto3-1.40.65.tar.gz", hash = "sha256:52e2715838d65e6b000e0077a942ce2d3e1a38f9764414ad01a602912eccf924", size = 111507, upload-time = "2025-11-03T21:56:57.12Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/a2/973a1346bb8d23ddda241342e126a26407e08648a556fb5022e0db457860/boto3-1.40.65-py3-none-any.whl", hash = "sha256:ab91d8d8ef0477997d35abebf67829e52e50bf807b02333affa384c70b33c86b", size = 139323, upload-time = "2025-11-03T21:56:55.125Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/a6/8e3209425650c96916b31324594db3ea9ec2eecc2b0acf6bbda0d2a6b1b2/botocore-1.40.65.tar.gz", hash = "sha256:cdbbf9d90a9e9c4a6000055013d98b92efc4ceb1bce0d9bcd70e14461dc22ab3", size = 14411821, upload-time = "2025-11-03T21:56:45.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/00/ccd1612ee99865435ad04ef477168af9d3a8d2ec6a7a694a37af47143543/botocore-1.40.65-py3-none-any.whl", hash = "sha256:152f595321f5a2b712601286650e912c2e5ca3b109892ab4c0175ac58d8de10d", size = 14075618, upload-time = "2025-11-03T21:56:42.011Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.10.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
+    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a3/da4153ec8fe25d263aa48c1a4cbde7f49b59af86f0b6f7862788c60da737/contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934", size = 268551, upload-time = "2025-04-15T17:34:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6c/330de89ae1087eb622bfca0177d32a7ece50c3ef07b28002de4757d9d875/contourpy-1.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc41ba0714aa2968d1f8674ec97504a8f7e334f48eeacebcaa6256213acb0989", size = 253399, upload-time = "2025-04-15T17:34:51.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/20c6726b1b7f81a8bee5271bed5c165f0a8e1f572578a9d27e2ccb763cb2/contourpy-1.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9be002b31c558d1ddf1b9b415b162c603405414bacd6932d031c5b5a8b757f0d", size = 312061, upload-time = "2025-04-15T17:34:55.961Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fc/a9665c88f8a2473f823cf1ec601de9e5375050f1958cbb356cdf06ef1ab6/contourpy-1.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2e74acbcba3bfdb6d9d8384cdc4f9260cae86ed9beee8bd5f54fee49a430b9", size = 351956, upload-time = "2025-04-15T17:35:00.992Z" },
+    { url = "https://files.pythonhosted.org/packages/25/eb/9f0a0238f305ad8fb7ef42481020d6e20cf15e46be99a1fcf939546a177e/contourpy-1.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e259bced5549ac64410162adc973c5e2fb77f04df4a439d00b478e57a0e65512", size = 320872, upload-time = "2025-04-15T17:35:06.177Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad687a04bc802cbe8b9c399c07162a3c35e227e2daccf1668eb1f278cb698631", size = 325027, upload-time = "2025-04-15T17:35:11.244Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bf/9baed89785ba743ef329c2b07fd0611d12bfecbedbdd3eeecf929d8d3b52/contourpy-1.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cdd22595308f53ef2f891040ab2b93d79192513ffccbd7fe19be7aa773a5e09f", size = 1306641, upload-time = "2025-04-15T17:35:26.701Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cc/74e5e83d1e35de2d28bd97033426b450bc4fd96e092a1f7a63dc7369b55d/contourpy-1.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b4f54d6a2defe9f257327b0f243612dd051cc43825587520b1bf74a31e2f6ef2", size = 1374075, upload-time = "2025-04-15T17:35:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/17f3b798fd5e033b46a16f8d9fcb39f1aba051307f5ebf441bad1ecf78f8/contourpy-1.3.2-cp310-cp310-win32.whl", hash = "sha256:f939a054192ddc596e031e50bb13b657ce318cf13d264f095ce9db7dc6ae81c0", size = 177534, upload-time = "2025-04-15T17:35:46.554Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ec/5162b8582f2c994721018d0c9ece9dc6ff769d298a8ac6b6a652c307e7df/contourpy-1.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:c440093bbc8fc21c637c03bafcbef95ccd963bc6e0514ad887932c18ca2a759a", size = 221188, upload-time = "2025-04-15T17:35:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/33/05/b26e3c6ecc05f349ee0013f0bb850a761016d89cec528a98193a48c34033/contourpy-1.3.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fd93cc7f3139b6dd7aab2f26a90dde0aa9fc264dbf70f6740d498a70b860b82c", size = 265681, upload-time = "2025-04-15T17:44:59.314Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/25/ac07d6ad12affa7d1ffed11b77417d0a6308170f44ff20fa1d5aa6333f03/contourpy-1.3.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:107ba8a6a7eec58bb475329e6d3b95deba9440667c4d62b9b6063942b61d7f16", size = 315101, upload-time = "2025-04-15T17:45:04.165Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/4d/5bb3192bbe9d3f27e3061a6a8e7733c9120e203cb8515767d30973f71030/contourpy-1.3.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ded1706ed0c1049224531b81128efbd5084598f18d8a2d9efae833edbd2b40ad", size = 220599, upload-time = "2025-04-15T17:45:08.456Z" },
+]
+
+[[package]]
+name = "coolname"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/c6/1eaa4495ff4640e80d9af64f540e427ba1596a20f735d4c4750fe0386d07/coolname-2.2.0.tar.gz", hash = "sha256:6c5d5731759104479e7ca195a9b64f7900ac5bead40183c09323c7d0be9e75c7", size = 59006, upload-time = "2023-01-09T14:50:41.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/b1/5745d7523d8ce53b87779f46ef6cf5c5c342997939c2fe967e607b944e43/coolname-2.2.0-py2.py3-none-any.whl", hash = "sha256:4d1563186cfaf71b394d5df4c744f8c41303b6846413645e31d31915cdeb13e8", size = 37849, upload-time = "2023-01-09T14:50:39.897Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/42/9c391dd801d6cf0d561b5890549d4b27bafcc53b39c31a817e69d87c625b/cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a", size = 7225004, upload-time = "2025-10-15T23:16:52.239Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/67/38769ca6b65f07461eb200e85fc1639b438bdc667be02cf7f2cd6a64601c/cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc", size = 4296667, upload-time = "2025-10-15T23:16:54.369Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload-time = "2025-10-15T23:16:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload-time = "2025-10-15T23:16:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload-time = "2025-10-15T23:17:00.378Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload-time = "2025-10-15T23:17:01.98Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload-time = "2025-10-15T23:17:04.078Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload-time = "2025-10-15T23:17:05.483Z" },
+    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload-time = "2025-10-15T23:17:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload-time = "2025-10-15T23:17:09.343Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload-time = "2025-10-15T23:17:11.22Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload-time = "2025-10-15T23:17:12.829Z" },
+    { url = "https://files.pythonhosted.org/packages/96/92/8a6a9525893325fc057a01f654d7efc2c64b9de90413adcf605a85744ff4/cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018", size = 3055988, upload-time = "2025-10-15T23:17:14.65Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/bf/80fbf45253ea585a1e492a6a17efcb93467701fa79e71550a430c5e60df0/cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb", size = 3514451, upload-time = "2025-10-15T23:17:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/af/9b302da4c87b0beb9db4e756386a7c6c5b8003cd0e742277888d352ae91d/cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c", size = 2928007, upload-time = "2025-10-15T23:17:18.04Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/23/45fe7f376a7df8daf6da3556603b36f53475a99ce4faacb6ba2cf3d82021/cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936", size = 7218248, upload-time = "2025-10-15T23:17:46.294Z" },
+    { url = "https://files.pythonhosted.org/packages/27/32/b68d27471372737054cbd34c84981f9edbc24fe67ca225d389799614e27f/cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683", size = 4294089, upload-time = "2025-10-15T23:17:48.269Z" },
+    { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload-time = "2025-10-15T23:17:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload-time = "2025-10-15T23:17:51.357Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload-time = "2025-10-15T23:17:52.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload-time = "2025-10-15T23:17:54.965Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload-time = "2025-10-15T23:17:56.754Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload-time = "2025-10-15T23:17:58.588Z" },
+    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload-time = "2025-10-15T23:18:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload-time = "2025-10-15T23:18:02.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload-time = "2025-10-15T23:18:04.85Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload-time = "2025-10-15T23:18:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload-time = "2025-10-15T23:18:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload-time = "2025-10-15T23:18:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload-time = "2025-10-15T23:18:12.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cd/1a8633802d766a0fa46f382a77e096d7e209e0817892929655fe0586ae32/cryptography-46.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a23582810fedb8c0bc47524558fb6c56aac3fc252cb306072fd2815da2a47c32", size = 3689163, upload-time = "2025-10-15T23:18:13.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/59/6b26512964ace6480c3e54681a9859c974172fb141c38df11eadd8416947/cryptography-46.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e7aec276d68421f9574040c26e2a7c3771060bc0cff408bae1dcb19d3ab1e63c", size = 3429474, upload-time = "2025-10-15T23:18:15.477Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "cyvcf2"
+version = "0.31.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coloredlogs" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/72/5f99e6d2ed239a2ad6d6c26c6726a4db11050e52d66ceb2262cf806a835f/cyvcf2-0.31.4.tar.gz", hash = "sha256:42f0c296b1f9a995c0240a1e33033d67ae728d6753ac129fdf90bddd5befaf57", size = 1331901, upload-time = "2025-10-13T17:47:16.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/bc/4cc66a1dbc20210d8bfa3fcfa76827927ac3ca9bb5b86a0409778e4b0e71/cyvcf2-0.31.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ca8ef53d7b58556f5c5d12b1e2717fd057246571cd966e8d92fc761819731e1d", size = 1392492, upload-time = "2025-10-13T17:46:19.415Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/58/2fce4fc87cfd75802e5f397470f00dfd15ec77a8164d457d67efa8d576f9/cyvcf2-0.31.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:364402abcf16ac9cb7045a971b0040d62e4f94eaf0bb68e5f48b321cd86adf7e", size = 1319996, upload-time = "2025-10-13T17:46:21.06Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ff/9d30128a88df6c795097b6f73218d4a5afcd0e2d74cf2dedd99b28d42cdc/cyvcf2-0.31.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c722f5e6357da2c2896429badd84a7013ca518d7538c40d93dc8d7c08cd7b9fe", size = 6789880, upload-time = "2025-10-13T17:46:22.36Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5d/5c1b960a3b7186e9b0458f20b9058b81829361200e7bcd120ef258d492bd/cyvcf2-0.31.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb0674bef30fa816342fa994dc4bd650e8888cd2964ac5c568501005f705d1e4", size = 7119307, upload-time = "2025-10-13T17:46:23.557Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7e/0d2fe258c846a8b61051b9442a66840ddc08a641a8453dcb12727d700211/cyvcf2-0.31.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b0c7a02e4994db39f5ebfd504592406e705c476ce08ac495c540a8dde1a210d1", size = 7296201, upload-time = "2025-10-13T17:46:25.233Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/8097bfc1226de885dbd45b7fb07ddb723f98c482a9d407b3cf5c52da534f/cyvcf2-0.31.4-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a29bc1bc06338bbd9e0210dc986fa785caafb878e24289e1bab58d875cc9e729", size = 1322180, upload-time = "2025-10-13T17:47:11.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/11/3ee983588647d2fc01cc8f5c8e9795f1b30c8f90904807fbac90320b2014/cyvcf2-0.31.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:a6388e048500f0355e1d404ccfb86331dda08d4506f8a1764d81fb92559aa0f6", size = 1271876, upload-time = "2025-10-13T17:47:12.08Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/2097c2d0243531cd17feb361b5f876019c244ee4e0a35ad95058d5909b5e/cyvcf2-0.31.4-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c3294000440c86d031019e50255981be1b133d175a00ded078a7b91c44bf727", size = 5207437, upload-time = "2025-10-13T17:47:13.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ed/5d5674718f595664e524a9c285b052ba10a744865db39cff703e920bdb6a/cyvcf2-0.31.4-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:608f4ca072ffca07ef5f02d760fb802b3c7759a99ee960b2f8a9fc322919f202", size = 5444235, upload-time = "2025-10-13T17:47:15.03Z" },
+]
+
+[[package]]
+name = "dask"
+version = "2025.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "fsspec" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "partd" },
+    { name = "pyyaml" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f0/d747f9517f2a50b835513da36a6da0cffa7d1f0a8b33f60e642ff78879a8/dask-2025.10.0.tar.gz", hash = "sha256:fd3159c319c27cea39b891c0f22d60056a33575fb4906618eab0aeeb5dcd0cbc", size = 10974677, upload-time = "2025-10-14T19:50:36.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/2b/36b8753d881ff8fcf9c57eadd2b9379815cbe08fde7ded4e52c4cbb4b227/dask-2025.10.0-py3-none-any.whl", hash = "sha256:86c0a4aecbed3eae938f13a52bcc3fdc35852cce34d7d701590c15850b92506e", size = 1481586, upload-time = "2025-10-14T19:50:21.983Z" },
+]
+
+[package.optional-dependencies]
+array = [
+    { name = "numpy" },
+]
+
+[[package]]
+name = "datacache"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "mock" },
+    { name = "pandas" },
+    { name = "progressbar33" },
+    { name = "requests" },
+    { name = "typechecks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/42/7ed665dad2b9acaab52965eb98a3f9fc34ae77dfc7706afbe583b986a846/datacache-1.4.1.tar.gz", hash = "sha256:acfdbdc550c7e0971b42ec0575cec2245ec4ace1cdfb9e931852db157e5b6c67", size = 19063, upload-time = "2024-02-13T19:51:50.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/bf/585fd1522561df26ae44caf40c827cb2f0ec3de5b2bb00d26117ad6b7663/datacache-1.4.1-py3-none-any.whl", hash = "sha256:a334747a2b849d7e4aa09aff3bc338ee10a97f02e5fe0237b6bb9254b4779635", size = 20258, upload-time = "2024-02-13T19:51:34.798Z" },
+]
+
+[[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/30/064144f0df1749e7bb5faaa7f52b007d7c2d08ec08fed8411aba87207f68/dateparser-1.2.2.tar.gz", hash = "sha256:986316f17cb8cdc23ea8ce563027c5ef12fc725b6fb1d137c14ca08777c5ecf7", size = 329840, upload-time = "2025-06-26T09:29:23.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/22/f020c047ae1346613db9322638186468238bcfa8849b4668a22b97faad65/dateparser-1.2.2-py3-none-any.whl", hash = "sha256:5a5d7211a09013499867547023a2a0c91d5a27d15dd4dbcea676ea9fe66f2482", size = 315453, upload-time = "2025-06-26T09:29:21.412Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
+]
+
+[[package]]
+name = "dirtyjson"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782, upload-time = "2022-11-28T23:32:33.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197, upload-time = "2022-11-28T23:32:31.219Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "eventlet"
+version = "0.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "greenlet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/4f/1e5227b23aa77d9ea05056b98cf0bf187cca994991060245002b640f9830/eventlet-0.40.3.tar.gz", hash = "sha256:290852db0065d78cec17a821b78c8a51cafb820a792796a354592ae4d5fceeb0", size = 565741, upload-time = "2025-08-27T09:56:16.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/b4/981362608131dc4ee8de9fdca6a38ef19e3da66ab6a13937bd158882db91/eventlet-0.40.3-py3-none-any.whl", hash = "sha256:e681cae6ee956cfb066a966b5c0541e734cc14879bda6058024104790595ac9d", size = 364333, upload-time = "2025-08-27T09:56:10.774Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "faiss-gpu"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/71/623896382d90a9a99adf3438aa2c575535ba37804be9701d66f3337afd83/faiss_gpu-1.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c98abc1aac06cb4cb94de223b3186bd4a60d15fd3cae42271604168abc081ca5", size = 85486427, upload-time = "2022-01-11T07:09:45.751Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.121.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/77a2df0946703973b9905fd0cde6172c15e0781984320123b4f5079e7113/fastapi-0.121.0.tar.gz", hash = "sha256:06663356a0b1ee93e875bbf05a31fb22314f5bed455afaaad2b2dad7f26e98fa", size = 342412, upload-time = "2025-11-03T10:25:54.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/2c/42277afc1ba1a18f8358561eee40785d27becab8f80a1f945c0a3051c6eb/fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106", size = 109183, upload-time = "2025-11-03T10:25:53.27Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/37/bcfa6c7d5eec777c4c7cf45ce6b27631cebe5230caf88d85eadd63edd37a/flask_cors-6.0.1.tar.gz", hash = "sha256:d81bcb31f07b0985be7f48406247e9243aced229b7747219160a0559edd678db", size = 13463, upload-time = "2025-06-11T01:32:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f8/01bf35a3afd734345528f98d0353f2a978a476528ad4d7e78b70c4d149dd/flask_cors-6.0.1-py3-none-any.whl", hash = "sha256:c7b2cbfb1a31aa0d2e5341eea03a6805349f7a61647daee1a15c46bbe981494c", size = 13244, upload-time = "2025-06-11T01:32:07.352Z" },
+]
+
+[[package]]
+name = "flask-jwt-extended"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "pyjwt" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/ea/2f97d46df8deb419ff98c8931cd7a3a142e967ac33522a2f2204449eee52/Flask-JWT-Extended-4.6.0.tar.gz", hash = "sha256:9215d05a9413d3855764bcd67035e75819d23af2fafb6b55197eb5a3313fdfb2", size = 34263, upload-time = "2023-12-13T05:29:37.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f7/b5415a5ec78666408cd9af9e8163e2953374808d222625cff33f64adfd2a/Flask_JWT_Extended-4.6.0-py2.py3-none-any.whl", hash = "sha256:63a28fc9731bcc6c4b8815b6f954b5904caa534fc2ae9b93b1d3ef12930dca95", size = 22676, upload-time = "2023-12-13T05:29:35.618Z" },
+]
+
+[[package]]
+name = "flask-restful"
+version = "0.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aniso8601" },
+    { name = "flask" },
+    { name = "pytz" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/ce/a0a133db616ea47f78a41e15c4c68b9f08cab3df31eb960f61899200a119/Flask-RESTful-0.3.10.tar.gz", hash = "sha256:fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37", size = 110453, upload-time = "2023-05-21T03:58:55.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/7b/f0b45f0df7d2978e5ae51804bb5939b7897b2ace24306009da0cc34d8d1f/Flask_RESTful-0.3.10-py2.py3-none-any.whl", hash = "sha256:1cf93c535172f112e080b0d4503a8d15f93a48c88bdd36dd87269bdaf405051b", size = 26217, upload-time = "2023-05-21T03:58:54.004Z" },
+]
+
+[[package]]
+name = "flask-socketio"
+version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "python-socketio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/1f/54d3de4982df695682af99c65d4b89f8a46fe6739780c5a68690195835a0/flask_socketio-5.5.1.tar.gz", hash = "sha256:d946c944a1074ccad8e99485a6f5c79bc5789e3ea4df0bb9c864939586c51ec4", size = 37401, upload-time = "2025-01-06T19:49:59.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/38/1b75b3ba3452860211ec87710f9854112911a436ee4d155533e0b83b5cd9/Flask_SocketIO-5.5.1-py3-none-any.whl", hash = "sha256:35a50166db44d055f68021d6ec32cb96f1f925cd82de4504314be79139ea846f", size = 18259, upload-time = "2025-01-06T19:49:56.555Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.60.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/42/97a13e47a1e51a5a7142475bbcf5107fe3a68fc34aef331c897d5fb98ad0/fonttools-4.60.1.tar.gz", hash = "sha256:ef00af0439ebfee806b25f24c8f92109157ff3fac5731dc7867957812e87b8d9", size = 3559823, upload-time = "2025-09-29T21:13:27.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/70/03e9d89a053caff6ae46053890eba8e4a5665a7c5638279ed4492e6d4b8b/fonttools-4.60.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9a52f254ce051e196b8fe2af4634c2d2f02c981756c6464dc192f1b6050b4e28", size = 2810747, upload-time = "2025-09-29T21:10:59.653Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/449ad5aff9670ab0df0f61ee593906b67a36d7e0b4d0cd7fa41ac0325bf5/fonttools-4.60.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7420a2696a44650120cdd269a5d2e56a477e2bfa9d95e86229059beb1c19e15", size = 2346909, upload-time = "2025-09-29T21:11:02.882Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/18/e5970aa96c8fad1cb19a9479cc3b7602c0c98d250fcdc06a5da994309c50/fonttools-4.60.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee0c0b3b35b34f782afc673d503167157094a16f442ace7c6c5e0ca80b08f50c", size = 4864572, upload-time = "2025-09-29T21:11:05.096Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/20/9b2b4051b6ec6689480787d506b5003f72648f50972a92d04527a456192c/fonttools-4.60.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:282dafa55f9659e8999110bd8ed422ebe1c8aecd0dc396550b038e6c9a08b8ea", size = 4794635, upload-time = "2025-09-29T21:11:08.651Z" },
+    { url = "https://files.pythonhosted.org/packages/10/52/c791f57347c1be98f8345e3dca4ac483eb97666dd7c47f3059aeffab8b59/fonttools-4.60.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4ba4bd646e86de16160f0fb72e31c3b9b7d0721c3e5b26b9fa2fc931dfdb2652", size = 4843878, upload-time = "2025-09-29T21:11:10.893Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e9/35c24a8d01644cee8c090a22fad34d5b61d1e0a8ecbc9945ad785ebf2e9e/fonttools-4.60.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0b0835ed15dd5b40d726bb61c846a688f5b4ce2208ec68779bc81860adb5851a", size = 4954555, upload-time = "2025-09-29T21:11:13.24Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/fb1e994971be4bdfe3a307de6373ef69a9df83fb66e3faa9c8114893d4cc/fonttools-4.60.1-cp310-cp310-win32.whl", hash = "sha256:1525796c3ffe27bb6268ed2a1bb0dcf214d561dfaf04728abf01489eb5339dce", size = 2232019, upload-time = "2025-09-29T21:11:15.73Z" },
+    { url = "https://files.pythonhosted.org/packages/40/84/62a19e2bd56f0e9fb347486a5b26376bade4bf6bbba64dda2c103bd08c94/fonttools-4.60.1-cp310-cp310-win_amd64.whl", hash = "sha256:268ecda8ca6cb5c4f044b1fb9b3b376e8cd1b361cef275082429dc4174907038", size = 2276803, upload-time = "2025-09-29T21:11:18.152Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/93/0dd45cd283c32dea1545151d8c3637b4b8c53cdb3a625aeb2885b184d74d/fonttools-4.60.1-py3-none-any.whl", hash = "sha256:906306ac7afe2156fcf0042173d6ebbb05416af70f6b370967b47f8f00103bbb", size = 1143175, upload-time = "2025-09-29T21:13:24.134Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fb/c85f9fed3ea8fe8740e5b46a59cc141c23b842eca617da8876cfce5f760e/frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565", size = 49621, upload-time = "2025-10-06T05:35:25.341Z" },
+    { url = "https://files.pythonhosted.org/packages/63/70/26ca3f06aace16f2352796b08704338d74b6d1a24ca38f2771afbb7ed915/frozenlist-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a88f062f072d1589b7b46e951698950e7da00442fc1cacbe17e19e025dc327ad", size = 49889, upload-time = "2025-10-06T05:35:26.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f57fb59d9f385710aa7060e89410aeb5058b99e62f4d16b08b91986b9a2140c2", size = 219464, upload-time = "2025-10-06T05:35:28.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/4d587dccbfca74cb8b810472392ad62bfa100bf8108c7223eb4c4fa2f7b3/frozenlist-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:799345ab092bee59f01a915620b5d014698547afd011e691a208637312db9186", size = 221649, upload-time = "2025-10-06T05:35:29.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/fd3b9cd046ec5fff9dab66831083bc2077006a874a2d3d9247dea93ddf7e/frozenlist-1.8.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c23c3ff005322a6e16f71bf8692fcf4d5a304aaafe1e262c98c6d4adc7be863e", size = 219188, upload-time = "2025-10-06T05:35:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/80/6693f55eb2e085fc8afb28cf611448fb5b90e98e068fa1d1b8d8e66e5c7d/frozenlist-1.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a76ea0f0b9dfa06f254ee06053d93a600865b3274358ca48a352ce4f0798450", size = 231748, upload-time = "2025-10-06T05:35:32.101Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d6/e9459f7c5183854abd989ba384fe0cc1a0fb795a83c033f0571ec5933ca4/frozenlist-1.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c7366fe1418a6133d5aa824ee53d406550110984de7637d65a178010f759c6ef", size = 236351, upload-time = "2025-10-06T05:35:33.834Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/24e97474b65c0262e9ecd076e826bfd1d3074adcc165a256e42e7b8a7249/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13d23a45c4cebade99340c4165bd90eeb4a56c6d8a9d8aa49568cac19a6d0dc4", size = 218767, upload-time = "2025-10-06T05:35:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bf/dc394a097508f15abff383c5108cb8ad880d1f64a725ed3b90d5c2fbf0bb/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e4a3408834f65da56c83528fb52ce7911484f0d1eaf7b761fc66001db1646eff", size = 235887, upload-time = "2025-10-06T05:35:36.354Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/25b201b9c015dbc999a5baf475a257010471a1fa8c200c843fd4abbee725/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:42145cd2748ca39f32801dad54aeea10039da6f86e303659db90db1c4b614c8c", size = 228785, upload-time = "2025-10-06T05:35:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f4/b5bc148df03082f05d2dd30c089e269acdbe251ac9a9cf4e727b2dbb8a3d/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e2de870d16a7a53901e41b64ffdf26f2fbb8917b3e6ebf398098d72c5b20bd7f", size = 230312, upload-time = "2025-10-06T05:35:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4b/87e95b5d15097c302430e647136b7d7ab2398a702390cf4c8601975709e7/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20e63c9493d33ee48536600d1a5c95eefc870cd71e7ab037763d1fbb89cc51e7", size = 217650, upload-time = "2025-10-06T05:35:40.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/78a0315d1fea97120591a83e0acd644da638c872f142fd72a6cebee825f3/frozenlist-1.8.0-cp310-cp310-win32.whl", hash = "sha256:adbeebaebae3526afc3c96fad434367cafbfd1b25d72369a9e5858453b1bb71a", size = 39659, upload-time = "2025-10-06T05:35:41.863Z" },
+    { url = "https://files.pythonhosted.org/packages/66/aa/3f04523fb189a00e147e60c5b2205126118f216b0aa908035c45336e27e4/frozenlist-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:667c3777ca571e5dbeb76f331562ff98b957431df140b54c85fd4d52eea8d8f6", size = 43837, upload-time = "2025-10-06T05:35:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/75/1135feecdd7c336938bd55b4dc3b0dfc46d85b9be12ef2628574b28de776/frozenlist-1.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:80f85f0a7cc86e7a54c46d99c9e1318ff01f4687c172ede30fd52d19d1da1c8e", size = 39989, upload-time = "2025-10-06T05:35:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2025.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/7f/2747c0d332b9acfa75dc84447a066fdf812b5a6b8d30472b74d309bfe8cb/fsspec-2025.10.0.tar.gz", hash = "sha256:b6789427626f068f9a83ca4e8a3cc050850b6c0f71f99ddb4f542b8266a26a59", size = 309285, upload-time = "2025-10-30T14:58:44.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/02/a6b21098b1d5d6249b7c5ab69dde30108a71e4e819d4a9778f1de1d5b70d/fsspec-2025.10.0-py3-none-any.whl", hash = "sha256:7c7712353ae7d875407f97715f0e1ffcc21e33d5b24556cb1e090ae9409ec61d", size = 200966, upload-time = "2025-10-30T14:58:42.53Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6b/22a77135757c3a7854c9f008ffed6bf4e8851616d77faf13147e9ab5aae6/google_auth-2.42.1.tar.gz", hash = "sha256:30178b7a21aa50bffbdc1ffcb34ff770a2f65c712170ecd5446c4bef4dc2b94e", size = 295541, upload-time = "2025-10-30T16:42:19.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/05/adeb6c495aec4f9d93f9e2fc29eeef6e14d452bba11d15bdb874ce1d5b10/google_auth-2.42.1-py2.py3-none-any.whl", hash = "sha256:eb73d71c91fc95dbd221a2eb87477c278a355e7367a35c0d84e6b0e5f9b4ad11", size = 222550, upload-time = "2025-10-30T16:42:17.878Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8d/88f3ebd2bc96bf7747093696f4335a0a8a4c5acfcf1b757717c0d2474ba3/greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f", size = 1137126, upload-time = "2025-08-07T13:18:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6f/b60b0291d9623c496638c582297ead61f43c4b72eef5e9c926ef4565ec13/greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c", size = 298654, upload-time = "2025-08-07T13:50:00.469Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
+]
+
+[[package]]
+name = "gseapy"
+version = "1.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "requests" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/ba/1b030db5efd590bec14bd8c30824f517623db811b7a2ab28f9327e406e95/gseapy-1.1.10.tar.gz", hash = "sha256:eedc0ab585f18fd4ecd11ac923da12fec2d80fccf7f5ede4178ae7311baf4b05", size = 112460, upload-time = "2025-09-12T17:59:58.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/87/756bc57fd183d54dea0014b28e8daf60b2fc06a5d0aa9991d593571b1573/gseapy-1.1.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:855f3d6d9e84b467027c0738294aaee2fa876be330b5da6d4020b267e8ccba43", size = 536478, upload-time = "2025-09-12T18:06:44.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/de/a4a76d5b1cf751b90a019f50c2cae37444e096b4ab7206f0700f9afba047/gseapy-1.1.10-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b381fda96e7dfedc4813ab9629d0fc25c84d529535919998e4b3c90bcd06cac", size = 600902, upload-time = "2025-09-12T18:03:13.021Z" },
+    { url = "https://files.pythonhosted.org/packages/65/29/dffdc12cdd30372d88deee111c500e12cab76d67acc4baeff082fff80626/gseapy-1.1.10-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:09775386083eb7fc5c6bee2ac02b27f34650a9829418ed7f91cac54d78415a2b", size = 583964, upload-time = "2025-09-12T18:45:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/52/ac5992a3a1bf9cf37c11e9a1bcda1d5136246b4df284d441d63627e7dd8a/gseapy-1.1.10-cp310-cp310-win32.whl", hash = "sha256:1042caa333e7dabc8902805f8c7fe2e05567f5b9302511dc79f3b04f423375b5", size = 390106, upload-time = "2025-09-12T18:10:01.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/65/3447f8f449b9157823404dd9c667c7cc6f82aa8816048db58733c94cd1a8/gseapy-1.1.10-cp310-cp310-win_amd64.whl", hash = "sha256:6ca2ec648f67d7068a14ca495edb1e06d34d7f45b1d9f3f47b2661df76535954", size = 420924, upload-time = "2025-09-12T18:07:21.242Z" },
+]
+
+[[package]]
+name = "gtfparse"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/bb/f97d06b60f32e30b7ba25336f0886c24b13855d7ca8642200e4d70382a45/gtfparse-1.3.0.tar.gz", hash = "sha256:d957f18e5f70413f89a28ef83068c461b6407eb38fd30e99b8da3d69143527b1", size = 16740, upload-time = "2022-12-01T22:26:14.344Z" }
+
+[[package]]
+name = "gwaslab"
+version = "3.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "adjusttext" },
+    { name = "biopython" },
+    { name = "gtfparse" },
+    { name = "h5py" },
+    { name = "liftover" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "pyensembl" },
+    { name = "pysam" },
+    { name = "scikit-allel" },
+    { name = "scipy" },
+    { name = "seaborn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/47/da271b9adf5aaa5c05e7db46748a147e0e4e5948e007ca002c30d5d06d71/gwaslab-3.6.10.tar.gz", hash = "sha256:7a02f6e9e1269c56f159b778d5b6ad349638745371c94ff25f2176f862843db2", size = 20829186, upload-time = "2025-11-01T14:37:49.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/d772314ab0732dc51321f9f9413fcd0087edeee001efad213cf7ca26ad75/gwaslab-3.6.10-py3-none-any.whl", hash = "sha256:438fad07224294a74560cea80820440d02925451a91aa0c51f6528009f1e4745", size = 20878340, upload-time = "2025-11-01T14:37:04.927Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/30/8fa61698b438dd751fa46a359792e801191dadab560d0a5f1c709443ef8e/h5py-3.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:67e59f6c2f19a32973a40f43d9a088ae324fe228c8366e25ebc57ceebf093a6b", size = 3414477, upload-time = "2025-10-16T10:33:24.201Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/db2f63302937337c4e9e51d97a5984b769bdb7488e3d37632a6ac297f8ef/h5py-3.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e2f471688402c3404fa4e13466e373e622fd4b74b47b56cfdff7cc688209422", size = 2850298, upload-time = "2025-10-16T10:33:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2e/f1bb7de9b05112bfd14d5206090f0f92f1e75bbb412fbec5d4653c3d44dd/h5py-3.15.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c45802bcb711e128a6839cb6c01e9ac648dc55df045c9542a675c771f15c8d5", size = 4523605, upload-time = "2025-10-16T10:33:31.168Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8a/63f4b08f3628171ce8da1a04681a65ee7ac338fde3cb3e9e3c9f7818e4da/h5py-3.15.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64ce3f6470adb87c06e3a8dd1b90e973699f1759ad79bfa70c230939bff356c9", size = 4735346, upload-time = "2025-10-16T10:33:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/74/48/f16d12d9de22277605bcc11c0dcab5e35f06a54be4798faa2636b5d44b3c/h5py-3.15.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4411c1867b9899a25e983fff56d820a66f52ac326bbe10c7cdf7d832c9dcd883", size = 4175305, upload-time = "2025-10-16T10:33:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/47cdbff65b2ce53c27458c6df63a232d7bb1644b97df37b2342442342c84/h5py-3.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2cbc4104d3d4aca9d6db8c0c694555e255805bfeacf9eb1349bda871e26cacbe", size = 4653602, upload-time = "2025-10-16T10:33:42.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/dc08de359c2f43a67baa529cb70d7f9599848750031975eed92d6ae78e1d/h5py-3.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:01f55111ca516f5568ae7a7fc8247dfce607de331b4467ee8a9a6ed14e5422c7", size = 2873601, upload-time = "2025-10-16T10:33:45.323Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
+    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
+    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/43/50033d25ad96a7f3845f40999b4778f753c3901a11808a584fed7c00d9f5/humanize-4.14.0.tar.gz", hash = "sha256:2fa092705ea640d605c435b1ca82b2866a1b601cdf96f076d70b79a855eba90d", size = 82939, upload-time = "2025-10-15T13:04:51.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/5b/9512c5fb6c8218332b530f13500c6ff5f3ce3342f35e0dd7be9ac3856fd3/humanize-4.14.0-py3-none-any.whl", hash = "sha256:d57701248d040ad456092820e6fde56c930f17749956ac47f4f655c0c547bfff", size = 132092, upload-time = "2025-10-15T13:04:49.404Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "hypothesis-generation-demo"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cyvcf2" },
+    { name = "eventlet" },
+    { name = "faiss-gpu" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "flask-jwt-extended" },
+    { name = "flask-restful" },
+    { name = "flask-socketio" },
+    { name = "gseapy" },
+    { name = "gwaslab" },
+    { name = "llama-index" },
+    { name = "llama-index-llms-anthropic" },
+    { name = "loguru" },
+    { name = "numpy" },
+    { name = "optuna" },
+    { name = "outlines" },
+    { name = "pandas" },
+    { name = "pengines" },
+    { name = "polars" },
+    { name = "prefect" },
+    { name = "psutil" },
+    { name = "pyjwt" },
+    { name = "pymongo" },
+    { name = "python-dotenv" },
+    { name = "python-socketio" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentence-transformers" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tzlocal" },
+    { name = "websocket-client" },
+]
+
+[package.optional-dependencies]
+r-integration = [
+    { name = "rpy2" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cyvcf2" },
+    { name = "eventlet" },
+    { name = "faiss-gpu" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "flask-jwt-extended", specifier = "==4.6.0" },
+    { name = "flask-restful" },
+    { name = "flask-socketio" },
+    { name = "gseapy" },
+    { name = "gwaslab" },
+    { name = "llama-index" },
+    { name = "llama-index-llms-anthropic" },
+    { name = "loguru" },
+    { name = "numpy", specifier = "==1.26.0" },
+    { name = "optuna" },
+    { name = "outlines" },
+    { name = "pandas" },
+    { name = "pengines" },
+    { name = "polars" },
+    { name = "prefect" },
+    { name = "psutil" },
+    { name = "pyjwt", specifier = "==2.9.0" },
+    { name = "pymongo" },
+    { name = "python-dotenv" },
+    { name = "python-socketio" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rpy2", marker = "extra == 'r-integration'" },
+    { name = "sentence-transformers" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tzlocal" },
+    { name = "websocket-client" },
+]
+provides-extras = ["r-integration"]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "isort"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinja2-humanize-extension"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanize" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/77/0bba383819dd4e67566487c11c49479ced87e77c3285d8e7f7a3401cf882/jinja2_humanize_extension-0.4.0.tar.gz", hash = "sha256:e7d69b1c20f32815bbec722330ee8af14b1287bb1c2b0afa590dbf031cadeaa0", size = 4746, upload-time = "2023-09-01T12:52:42.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b4/08c9d297edd5e1182506edecccbb88a92e1122a057953068cadac420ca5d/jinja2_humanize_extension-0.4.0-py3-none-any.whl", hash = "sha256:b6326e2da0f7d425338bebf58848e830421defbce785f12ae812e65128518156", size = 4769, upload-time = "2023-09-01T12:52:41.098Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/68/0357982493a7b20925aece061f7fb7a2678e3b232f8d73a6edb7e5304443/jiter-0.11.1.tar.gz", hash = "sha256:849dcfc76481c0ea0099391235b7ca97d7279e0fa4c86005457ac7c88e8b76dc", size = 168385, upload-time = "2025-10-17T11:31:15.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/10/d099def5716452c8d5ffa527405373a44ddaf8e3c9d4f6de1e1344cffd90/jiter-0.11.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ed58841a491bbbf3f7c55a6b68fff568439ab73b2cce27ace0e169057b5851df", size = 310078, upload-time = "2025-10-17T11:28:36.186Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/b81d010b0031ffa96dfb590628562ac5f513ce56aa2ab451d29fb3fedeb9/jiter-0.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:499beb9b2d7e51d61095a8de39ebcab1d1778f2a74085f8305a969f6cee9f3e4", size = 317138, upload-time = "2025-10-17T11:28:38.294Z" },
+    { url = "https://files.pythonhosted.org/packages/89/12/31ea12af9d79671cc7bd893bf0ccaf3467624c0fc7146a0cbfe7b549bcfa/jiter-0.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b87b2821795e28cc990939b68ce7a038edea680a24910bd68a79d54ff3f03c02", size = 348964, upload-time = "2025-10-17T11:28:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/95cb6dc5ff962410667a29708c7a6c0691cc3c4866a0bfa79d085b56ebd6/jiter-0.11.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83f6fa494d8bba14ab100417c80e70d32d737e805cb85be2052d771c76fcd1f8", size = 363289, upload-time = "2025-10-17T11:28:41.49Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3e/37006ad5843a0bc3a3ec3a6c44710d7a154113befaf5f26d2fe190668b63/jiter-0.11.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5fbc6aea1daa2ec6f5ed465f0c5e7b0607175062ceebbea5ca70dd5ddab58083", size = 487243, upload-time = "2025-10-17T11:28:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5c/d38c8c801a322a0c0de47b9618c16fd766366f087ce37c4e55ae8e3c8b03/jiter-0.11.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:302288e2edc43174bb2db838e94688d724f9aad26c5fb9a74f7a5fb427452a6a", size = 376139, upload-time = "2025-10-17T11:28:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cd/442ad2389a5570b0ee673f93e14bbe8cdecd3e08a9ba7756081d84065e4c/jiter-0.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85db563fe3b367bb568af5d29dea4d4066d923b8e01f3417d25ebecd958de815", size = 359279, upload-time = "2025-10-17T11:28:46.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/35/8f5810d0e7d00bc395889085dbc1ccc36d454b56f28b2a5359dfd1bab48d/jiter-0.11.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f1c1ba2b6b22f775444ef53bc2d5778396d3520abc7b2e1da8eb0c27cb3ffb10", size = 384911, upload-time = "2025-10-17T11:28:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bd/8c069ceb0bafcf6b4aa5de0c27f02faf50468df39564a02e1a12389ad6c2/jiter-0.11.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:523be464b14f8fd0cc78da6964b87b5515a056427a2579f9085ce30197a1b54a", size = 517879, upload-time = "2025-10-17T11:28:49.902Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3c/9163efcf762f79f47433078b4f0a1bddc56096082c02c6cae2f47f07f56f/jiter-0.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25b99b3f04cd2a38fefb22e822e35eb203a2cd37d680dbbc0c0ba966918af336", size = 508739, upload-time = "2025-10-17T11:28:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/44/07/50690f257935845d3114b95b5dd03749eeaab5e395cbb522f9e957da4551/jiter-0.11.1-cp310-cp310-win32.whl", hash = "sha256:47a79e90545a596bb9104109777894033347b11180d4751a216afef14072dbe7", size = 203948, upload-time = "2025-10-17T11:28:54.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/5964a944bf2e98ffd566153fdc2a6a368fcb11b58cc46832ca8c75808dba/jiter-0.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:cace75621ae9bd66878bf69fbd4dfc1a28ef8661e0c2d0eb72d3d6f1268eddf5", size = 207522, upload-time = "2025-10-17T11:28:56.79Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564, upload-time = "2025-08-10T21:27:49.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5d/8ce64e36d4e3aac5ca96996457dcf33e34e6051492399a3f1fec5657f30b/kiwisolver-1.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b4b4d74bda2b8ebf4da5bd42af11d02d04428b2c32846e4c2c93219df8a7987b", size = 124159, upload-time = "2025-08-10T21:25:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1e/22f63ec454874378175a5f435d6ea1363dd33fb2af832c6643e4ccea0dc8/kiwisolver-1.4.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fb3b8132019ea572f4611d770991000d7f58127560c4889729248eb5852a102f", size = 66578, upload-time = "2025-08-10T21:25:36.73Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4c/1925dcfff47a02d465121967b95151c82d11027d5ec5242771e580e731bd/kiwisolver-1.4.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:84fd60810829c27ae375114cd379da1fa65e6918e1da405f356a775d49a62bcf", size = 65312, upload-time = "2025-08-10T21:25:37.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/42/0f333164e6307a0687d1eb9ad256215aae2f4bd5d28f4653d6cd319a3ba3/kiwisolver-1.4.9-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b78efa4c6e804ecdf727e580dbb9cba85624d2e1c6b5cb059c66290063bd99a9", size = 1628458, upload-time = "2025-08-10T21:25:39.067Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b6/2dccb977d651943995a90bfe3495c2ab2ba5cd77093d9f2318a20c9a6f59/kiwisolver-1.4.9-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4efec7bcf21671db6a3294ff301d2fc861c31faa3c8740d1a94689234d1b415", size = 1225640, upload-time = "2025-08-10T21:25:40.489Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2b/362ebd3eec46c850ccf2bfe3e30f2fc4c008750011f38a850f088c56a1c6/kiwisolver-1.4.9-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90f47e70293fc3688b71271100a1a5453aa9944a81d27ff779c108372cf5567b", size = 1244074, upload-time = "2025-08-10T21:25:42.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/bb/f09a1e66dab8984773d13184a10a29fe67125337649d26bdef547024ed6b/kiwisolver-1.4.9-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fdca1def57a2e88ef339de1737a1449d6dbf5fab184c54a1fca01d541317154", size = 1293036, upload-time = "2025-08-10T21:25:43.801Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/01/11ecf892f201cafda0f68fa59212edaea93e96c37884b747c181303fccd1/kiwisolver-1.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9cf554f21be770f5111a1690d42313e140355e687e05cf82cb23d0a721a64a48", size = 2175310, upload-time = "2025-08-10T21:25:45.045Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5f/bfe11d5b934f500cc004314819ea92427e6e5462706a498c1d4fc052e08f/kiwisolver-1.4.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1795ac5cd0510207482c3d1d3ed781143383b8cfd36f5c645f3897ce066220", size = 2270943, upload-time = "2025-08-10T21:25:46.393Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/259f786bf71f1e03e73d87e2db1a9a3bcab64d7b4fd780167123161630ad/kiwisolver-1.4.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:ccd09f20ccdbbd341b21a67ab50a119b64a403b09288c27481575105283c1586", size = 2440488, upload-time = "2025-08-10T21:25:48.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/76/c989c278faf037c4d3421ec07a5c452cd3e09545d6dae7f87c15f54e4edf/kiwisolver-1.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:540c7c72324d864406a009d72f5d6856f49693db95d1fbb46cf86febef873634", size = 2246787, upload-time = "2025-08-10T21:25:49.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/55/c2898d84ca440852e560ca9f2a0d28e6e931ac0849b896d77231929900e7/kiwisolver-1.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:ede8c6d533bc6601a47ad4046080d36b8fc99f81e6f1c17b0ac3c2dc91ac7611", size = 73730, upload-time = "2025-08-10T21:25:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/09/486d6ac523dd33b80b368247f238125d027964cfacb45c654841e88fb2ae/kiwisolver-1.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:7b4da0d01ac866a57dd61ac258c5607b4cd677f63abaec7b148354d2b2cdd536", size = 65036, upload-time = "2025-08-10T21:25:52.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/63/fde392691690f55b38d5dd7b3710f5353bf7a8e52de93a22968801ab8978/kiwisolver-1.4.9-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:4d1d9e582ad4d63062d34077a9a1e9f3c34088a2ec5135b1f7190c07cf366527", size = 60183, upload-time = "2025-08-10T21:27:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b1/6aad34edfdb7cced27f371866f211332bba215bfd918ad3322a58f480d8b/kiwisolver-1.4.9-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:deed0c7258ceb4c44ad5ec7d9918f9f14fd05b2be86378d86cf50e63d1e7b771", size = 58675, upload-time = "2025-08-10T21:27:39.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1a/23d855a702bb35a76faed5ae2ba3de57d323f48b1f6b17ee2176c4849463/kiwisolver-1.4.9-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a590506f303f512dff6b7f75fd2fd18e16943efee932008fe7140e5fa91d80e", size = 80277, upload-time = "2025-08-10T21:27:40.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5b/5239e3c2b8fb5afa1e8508f721bb77325f740ab6994d963e61b2b7abcc1e/kiwisolver-1.4.9-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e09c2279a4d01f099f52d5c4b3d9e208e91edcbd1a175c9662a8b16e000fece9", size = 77994, upload-time = "2025-08-10T21:27:41.181Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1c/5d4d468fb16f8410e596ed0eac02d2c68752aa7dc92997fe9d60a7147665/kiwisolver-1.4.9-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c9e7cdf45d594ee04d5be1b24dd9d49f3d1590959b2271fb30b5ca2b262c00fb", size = 73744, upload-time = "2025-08-10T21:27:42.254Z" },
+]
+
+[[package]]
+name = "liftover"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/d3/4395023ec9bea950d18ebd960001467c44e6f581b316887b0abeaf024d80/liftover-1.3.1.tar.gz", hash = "sha256:43173ba201f2ad2ffd84c699b228d3f21da58e4d087d15d8bdcf600697ade10c", size = 218113, upload-time = "2024-07-18T19:38:46.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4e/8511661478417bfbf952cd8aceafafb9e7fafa969f0a5c3d306f38506f4d/liftover-1.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9f7254b79a4624b87e68fa053a3fd4c6dd17edfcd61b03cc3aaddebb6cc67da", size = 72547, upload-time = "2024-07-18T19:37:26.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/65/2ad2c1d415ed96bad60202a4eec35de08827148d88b511837fa6aa0ed707/liftover-1.3.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74d4c233e45bce7b4c26746d7ebeccd542c265fe7947bff7ac28f6137dbd0757", size = 1024081, upload-time = "2024-07-18T19:37:28.333Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b5/ea4ddfdfd1c3a25e4870f282d0a0a826fc3d04dddec8a75f0d9f5159ec2a/liftover-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1adb73febcb982a502172b5c6a126400e4abbf0056d712dec9b673b2b0136a9", size = 1041969, upload-time = "2024-07-18T19:37:30.307Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4f/75d44915f4f68960928c756ccfaf3cdc9335499f54654829b0f5a12cbb60/liftover-1.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:056db61d497be06095ca86675544c41aea994b1c4f6036a3b2061f8b63494c55", size = 1900981, upload-time = "2024-07-18T19:37:32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c1/674e84c16bab0ae0325d67d3d8247f0ab188edc15951fd4707222dbc22fd/liftover-1.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:30580704e7549ae3cf5f3062212c6e06258063925990b1a3bf8bcfc0df010392", size = 1877628, upload-time = "2024-07-18T19:37:37.473Z" },
+    { url = "https://files.pythonhosted.org/packages/53/08/3aa0ba247f7b1a2fce18ad93be5590c7b5d760e659273ecee25a825a02fe/liftover-1.3.1-cp310-cp310-win32.whl", hash = "sha256:6b7c1b3b8696c4f6e1a2454dc39e004706fb541c0216ffac788025478138cfca", size = 90899, upload-time = "2024-07-18T19:37:39.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ca/c97b880dc289e618eca53b663620ad7826a11a563b73d3fa7abfa8fc13f0/liftover-1.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:651f9d04681090637c56e60db7a42440e6dc65356bc1ad9211fae6f5c881e012", size = 99998, upload-time = "2024-07-18T19:37:40.755Z" },
+]
+
+[[package]]
+name = "llama-cloud"
+version = "0.1.35"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/72/816e6e900448e1b4a8137d90e65876b296c5264a23db6ae888bd3e6660ba/llama_cloud-0.1.35.tar.gz", hash = "sha256:200349d5d57424d7461f304cdb1355a58eea3e6ca1e6b0d75c66b2e937216983", size = 106403, upload-time = "2025-07-28T17:22:06.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/d2/8d18a021ab757cea231428404f21fe3186bf1ebaac3f57a73c379483fd3f/llama_cloud-0.1.35-py3-none-any.whl", hash = "sha256:b7abab4423118e6f638d2f326749e7a07c6426543bea6da99b623c715b22af71", size = 303280, upload-time = "2025-07-28T17:22:04.946Z" },
+]
+
+[[package]]
+name = "llama-cloud-services"
+version = "0.6.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "llama-cloud" },
+    { name = "llama-index-core" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/0c/8ca87d33bea0340a8ed791f36390112aeb29fd3eebfd64b6aef6204a03f0/llama_cloud_services-0.6.54.tar.gz", hash = "sha256:baf65d9bffb68f9dca98ac6e22908b6675b2038b021e657ead1ffc0e43cbd45d", size = 53468, upload-time = "2025-08-01T20:09:20.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/48/4e295e3f791b279885a2e584f71e75cbe4ac84e93bba3c36e2668f60a8ac/llama_cloud_services-0.6.54-py3-none-any.whl", hash = "sha256:07f595f7a0ba40c6a1a20543d63024ca7600fe65c4811d1951039977908997be", size = 63874, upload-time = "2025-08-01T20:09:20.076Z" },
+]
+
+[[package]]
+name = "llama-index"
+version = "0.14.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-cli" },
+    { name = "llama-index-core" },
+    { name = "llama-index-embeddings-openai" },
+    { name = "llama-index-indices-managed-llama-cloud" },
+    { name = "llama-index-llms-openai" },
+    { name = "llama-index-readers-file" },
+    { name = "llama-index-readers-llama-parse" },
+    { name = "nltk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/f1/ebf6b88319627a0de9acb2593ec54e5835f6d3caf3299221e548acc4d9da/llama_index-0.14.7.tar.gz", hash = "sha256:cdc269b332e7946efb6d8f13a0eb38cecdea44cd69ebfe40e7ea9c716bdb736b", size = 8456, upload-time = "2025-10-30T23:58:39.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/f5/de6f59da3bb70b98ce0e384c3b39e23f087b7a1810e625452a1fd630a1bd/llama_index-0.14.7-py3-none-any.whl", hash = "sha256:80a5a1390f49e4c059ae733a95b7449a43cf90b56dab9100d78bfa9a1963a158", size = 7448, upload-time = "2025-10-30T23:58:38.431Z" },
+]
+
+[[package]]
+name = "llama-index-cli"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-embeddings-openai" },
+    { name = "llama-index-llms-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/84/41e820efffbe327c38228d3b37fe42512a37e0c3ee4ff6bf97a394e9577a/llama_index_cli-0.5.3.tar.gz", hash = "sha256:ebaf39e785efbfa8d50d837f60cb0f95125c04bf73ed1f92092a2a5f506172f8", size = 24821, upload-time = "2025-09-29T18:03:10.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/81/b7b3778aa8662913760fbbee77578daf4407aeaa677ccbf0125c4cfa2e67/llama_index_cli-0.5.3-py3-none-any.whl", hash = "sha256:7deb1e953e582bd885443881ce8bd6ab2817b594fef00079dce9993c47d990f7", size = 28173, upload-time = "2025-09-29T18:03:10.024Z" },
+]
+
+[[package]]
+name = "llama-index-core"
+version = "0.14.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "banks" },
+    { name = "dataclasses-json" },
+    { name = "deprecated" },
+    { name = "dirtyjson" },
+    { name = "filetype" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "llama-index-workflows" },
+    { name = "nest-asyncio" },
+    { name = "networkx" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a8/11f128ad6e1918ae56aecf4f99619ef16acba31a7dfdad47f9801dc7ab0b/llama_index_core-0.14.7.tar.gz", hash = "sha256:ceacf30131b84c72e4881748ef428f5392ab484adf1c0e7e0f1048b2b98eb70e", size = 11578585, upload-time = "2025-10-30T23:08:09.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/0a/5e9b9b1b10b58df1f6c219872b19ffd41cc49bdad58b1c24a2c971883c11/llama_index_core-0.14.7-py3-none-any.whl", hash = "sha256:568591a27dd171f9d5299155920bfef6bac9e7fa59df200404877a57b7973765", size = 11919918, upload-time = "2025-10-30T23:08:06.202Z" },
+]
+
+[[package]]
+name = "llama-index-embeddings-openai"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/36/90336d054a5061a3f5bc17ac2c18ef63d9d84c55c14d557de484e811ea4d/llama_index_embeddings_openai-0.5.1.tar.gz", hash = "sha256:1c89867a48b0d0daa3d2d44f5e76b394b2b2ef9935932daf921b9e77939ccda8", size = 7020, upload-time = "2025-09-08T20:17:44.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/4a/8ab11026cf8deff8f555aa73919be0bac48332683111e5fc4290f352dc50/llama_index_embeddings_openai-0.5.1-py3-none-any.whl", hash = "sha256:a2fcda3398bbd987b5ce3f02367caee8e84a56b930fdf43cc1d059aa9fd20ca5", size = 7011, upload-time = "2025-09-08T20:17:44.015Z" },
+]
+
+[[package]]
+name = "llama-index-indices-managed-llama-cloud"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "llama-cloud" },
+    { name = "llama-index-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/4a/79044fcb3209583d1ffe0c2a7c19dddfb657a03faeb9fe0cf5a74027e646/llama_index_indices_managed_llama_cloud-0.9.4.tar.gz", hash = "sha256:b5e00752ab30564abf19c57595a2107f5697c3b03b085817b4fca84a38ebbd59", size = 15146, upload-time = "2025-09-08T20:29:58.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/6a/0e33245df06afc9766c46a1fe92687be8a09da5d0d0128bc08d84a9f5efa/llama_index_indices_managed_llama_cloud-0.9.4-py3-none-any.whl", hash = "sha256:535a08811046803ca6ab7f8e9d510e926aa5306608b02201ad3d9d21701383bc", size = 17005, upload-time = "2025-09-08T20:29:57.876Z" },
+]
+
+[[package]]
+name = "llama-index-instrumentation"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/b9/a7a74de6d8aacf4be329329495983d78d96b1a6e69b6d9fcf4a233febd4b/llama_index_instrumentation-0.4.2.tar.gz", hash = "sha256:dc4957b64da0922060690e85a6be9698ac08e34e0f69e90b01364ddec4f3de7f", size = 46146, upload-time = "2025-10-13T20:44:48.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/54/df8063b0441242e250e03d1e31ebde5dffbe24e1af32b025cb1a4544150c/llama_index_instrumentation-0.4.2-py3-none-any.whl", hash = "sha256:b4989500e6454059ab3f3c4a193575d47ab1fadb730c2e8f2b962649ae88b70b", size = 15411, upload-time = "2025-10-13T20:44:47.685Z" },
+]
+
+[[package]]
+name = "llama-index-llms-anthropic"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic", extra = ["bedrock", "vertex"] },
+    { name = "llama-index-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/71/2b7f86151c9fafb092cac972ffd5fd4c72839222c29e7c4a8371d7a69b7a/llama_index_llms_anthropic-0.10.0.tar.gz", hash = "sha256:95b239f165b080e1d3e0ed35f5c9a12c62570fdc635435164b53105786ccf2db", size = 13866, upload-time = "2025-10-27T19:28:54.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/9d/526054172066129c28c186fab07c28ed3f86b2b674b4db2f73d748c15db1/llama_index_llms_anthropic-0.10.0-py3-none-any.whl", hash = "sha256:663843040b79688e6a89b865c8a93f477f85b23c308b5b5ee91a323231854cda", size = 14312, upload-time = "2025-10-27T19:28:54.096Z" },
+]
+
+[[package]]
+name = "llama-index-llms-openai"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/64/62c079203c659ba379a286c36d556a9f88098976d4eac76ed3892d42fc0b/llama_index_llms_openai-0.6.7.tar.gz", hash = "sha256:70ec68233fc4a3fbce3fccd21ad427013a74e51768986d4e57a1860365abc824", size = 25518, upload-time = "2025-11-03T15:20:03.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/a2/1180fe8133bf9aac067d26526bf7e89362f45ebae7993efadb4718fcbd0d/llama_index_llms_openai-0.6.7-py3-none-any.whl", hash = "sha256:39dbffb8d31f9bf9f4fa799042ff1f06aefc735387adaae17c2facc867093351", size = 26520, upload-time = "2025-11-03T15:20:02.129Z" },
+]
+
+[[package]]
+name = "llama-index-readers-file"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "defusedxml" },
+    { name = "llama-index-core" },
+    { name = "pandas" },
+    { name = "pypdf" },
+    { name = "striprtf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/d9/c67ad2b9cba8dacf1d4a55fe5432357b6eceaecfb096a0de5c1cbd959b98/llama_index_readers_file-0.5.4.tar.gz", hash = "sha256:5e766f32597622e66529464101914548ad683770a0a5d2bdc9ee84eb3a110332", size = 32565, upload-time = "2025-09-08T20:39:40.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/e3/76d72a7281b9c88d488908731c9034e1ee1a2cad5aa1dead76b051eca989/llama_index_readers_file-0.5.4-py3-none-any.whl", hash = "sha256:135be5ddda66c5b35883911918b2d99f67a2ab010d180af5630c872ea9509d45", size = 51827, upload-time = "2025-09-08T20:39:39.408Z" },
+]
+
+[[package]]
+name = "llama-index-readers-llama-parse"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-parse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/77/5bfaab20e6ec8428dbf2352e18be550c957602723d69383908176b5686cd/llama_index_readers_llama_parse-0.5.1.tar.gz", hash = "sha256:2b78b73faa933e30e6c69df351e4e9f36dfe2ae142e2ab3969ddd2ac48930e37", size = 3858, upload-time = "2025-09-08T20:41:29.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/81/52410c7245dcbf1a54756a9ce3892cdd167ec0b884d696de1304ca3f452e/llama_index_readers_llama_parse-0.5.1-py3-none-any.whl", hash = "sha256:0d41450ed29b0c49c024e206ef6c8e662b1854e77a1c5faefed3b958be54f880", size = 3203, upload-time = "2025-09-08T20:41:28.438Z" },
+]
+
+[[package]]
+name = "llama-index-workflows"
+version = "2.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-instrumentation" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/f5/2400c2b5b36dd34b89c8189ce51e008ad0fc7dff4f0b0bd3bb19427927f5/llama_index_workflows-2.10.3.tar.gz", hash = "sha256:3e9b21adf56f03d0c3e94eab3ac873f2914a8b31b721278d600eefebaed5ae2d", size = 5237264, upload-time = "2025-11-03T16:13:14.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/1c/1893faa66090c410f1401f8de0877c6813fe85ba13c3aa5254a658e88e84/llama_index_workflows-2.10.3-py3-none-any.whl", hash = "sha256:63c54c55628e7d6e722cc6d04b57790448da901d3cdd5f9bc93698e3d868c6da", size = 91532, upload-time = "2025-11-03T16:13:12.876Z" },
+]
+
+[[package]]
+name = "llama-parse"
+version = "0.6.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-cloud-services" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/f6/93b5d123c480bc8c93e6dc3ea930f4f8df8da27f829bb011100ba3ce23dc/llama_parse-0.6.54.tar.gz", hash = "sha256:c707b31152155c9bae84e316fab790bbc8c85f4d8825ce5ee386ebeb7db258f1", size = 3577, upload-time = "2025-08-01T20:09:23.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/50/c5ccd2a50daa0a10c7f3f7d4e6992392454198cd8a7d99fcb96cb60d0686/llama_parse-0.6.54-py3-none-any.whl", hash = "sha256:c66c8d51cf6f29a44eaa8595a595de5d2598afc86e5a33a4cebe5fe228036920", size = 4879, upload-time = "2025-08-01T20:09:22.651Z" },
+]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+]
+
+[[package]]
+name = "marshmallow"
+version = "3.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825, upload-time = "2025-02-03T15:32:25.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878, upload-time = "2025-02-03T15:32:22.295Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/4f/8487737a74d8be4ab5fbe6019b0fae305c1604cf7209500969b879b5f462/matplotlib-3.8.4.tar.gz", hash = "sha256:8aac397d5e9ec158960e31c381c5ffc52ddd52bd9a47717e2a694038167dffea", size = 35934425, upload-time = "2024-04-04T01:47:18.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/c0/1f88491656d21a2fecd90fbfae999b2f87bc44d439ef301ec8e0e4a937a0/matplotlib-3.8.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:abc9d838f93583650c35eca41cfcec65b2e7cb50fd486da6f0c49b5e1ed23014", size = 7603557, upload-time = "2024-04-04T01:47:46.363Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9c/aa059a4fb8154d5875a5ddd33f8d0a42d77c0225fe4325e9b9358f39b0bf/matplotlib-3.8.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f65c9f002d281a6e904976007b2d46a1ee2bcea3a68a8c12dda24709ddc9106", size = 7497421, upload-time = "2024-04-04T01:47:54.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/67/ded5217d42de1532193cd87db925c67997d23c68b20c3eaa9e4c6a0adb67/matplotlib-3.8.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce1edd9f5383b504dbc26eeea404ed0a00656c526638129028b758fd43fc5f10", size = 11377985, upload-time = "2024-04-04T01:48:04.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/061f97211f942101070a46fecd813a6b1bd83590ed7b07c473cabd707fe7/matplotlib-3.8.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecd79298550cba13a43c340581a3ec9c707bd895a6a061a78fa2524660482fc0", size = 11608003, upload-time = "2024-04-04T01:48:16.25Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d3/5d0bb1d905e219543fdfd7ab04e9d641a766367c83a5ffbcea60d2b2cf2d/matplotlib-3.8.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:90df07db7b599fe7035d2f74ab7e438b656528c68ba6bb59b7dc46af39ee48ef", size = 9535368, upload-time = "2024-04-04T01:48:26.265Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5a/a5108ae3db37f35f8a2be8a57d62da327af239214c9661464ce09ee32d7d/matplotlib-3.8.4-cp310-cp310-win_amd64.whl", hash = "sha256:ac24233e8f2939ac4fd2919eed1e9c0871eac8057666070e94cbf0b33dd9c338", size = 7656037, upload-time = "2024-04-04T01:48:34.761Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "memoized-property"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/db/23f8b5d86c9385299586c2469b58087f658f58eaeb414be0fd64cfd054e1/memoized-property-1.0.3.tar.gz", hash = "sha256:4be4d0209944b9b9b678dae9d7e312249fe2e6fb8bdc9bdaa1da4de324f0fcf5", size = 5011, upload-time = "2016-09-29T06:16:34.77Z" }
+
+[[package]]
+name = "mock"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0", size = 92796, upload-time = "2025-03-03T12:31:42.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f", size = 31617, upload-time = "2025-03-03T12:31:41.518Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/1e/5492c365f222f907de1039b91f922b93fa4f764c713ee858d235495d8f50/multidict-6.7.0.tar.gz", hash = "sha256:c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5", size = 101834, upload-time = "2025-10-06T14:52:30.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/63/7bdd4adc330abcca54c85728db2327130e49e52e8c3ce685cec44e0f2e9f/multidict-6.7.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9f474ad5acda359c8758c8accc22032c6abe6dc87a8be2440d097785e27a9349", size = 77153, upload-time = "2025-10-06T14:48:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/bb/b6c35ff175ed1a3142222b78455ee31be71a8396ed3ab5280fbe3ebe4e85/multidict-6.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a9db5a870f780220e931d0002bbfd88fb53aceb6293251e2c839415c1b20e", size = 44993, upload-time = "2025-10-06T14:48:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1f/064c77877c5fa6df6d346e68075c0f6998547afe952d6471b4c5f6a7345d/multidict-6.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03ca744319864e92721195fa28c7a3b2bc7b686246b35e4078c1e4d0eb5466d3", size = 44607, upload-time = "2025-10-06T14:48:29.581Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7a/bf6aa92065dd47f287690000b3d7d332edfccb2277634cadf6a810463c6a/multidict-6.7.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f0e77e3c0008bc9316e662624535b88d360c3a5d3f81e15cf12c139a75250046", size = 241847, upload-time = "2025-10-06T14:48:32.107Z" },
+    { url = "https://files.pythonhosted.org/packages/94/39/297a8de920f76eda343e4ce05f3b489f0ab3f9504f2576dfb37b7c08ca08/multidict-6.7.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08325c9e5367aa379a3496aa9a022fe8837ff22e00b94db256d3a1378c76ab32", size = 242616, upload-time = "2025-10-06T14:48:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3a/d0eee2898cfd9d654aea6cb8c4addc2f9756e9a7e09391cfe55541f917f7/multidict-6.7.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e2862408c99f84aa571ab462d25236ef9cb12a602ea959ba9c9009a54902fc73", size = 222333, upload-time = "2025-10-06T14:48:35.9Z" },
+    { url = "https://files.pythonhosted.org/packages/05/48/3b328851193c7a4240815b71eea165b49248867bbb6153a0aee227a0bb47/multidict-6.7.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d72a9a2d885f5c208b0cb91ff2ed43636bb7e345ec839ff64708e04f69a13cc", size = 253239, upload-time = "2025-10-06T14:48:37.302Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ca/0706a98c8d126a89245413225ca4a3fefc8435014de309cf8b30acb68841/multidict-6.7.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:478cc36476687bac1514d651cbbaa94b86b0732fb6855c60c673794c7dd2da62", size = 251618, upload-time = "2025-10-06T14:48:38.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4f/9c7992f245554d8b173f6f0a048ad24b3e645d883f096857ec2c0822b8bd/multidict-6.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6843b28b0364dc605f21481c90fadb5f60d9123b442eb8a726bb74feef588a84", size = 241655, upload-time = "2025-10-06T14:48:40.312Z" },
+    { url = "https://files.pythonhosted.org/packages/31/79/26a85991ae67efd1c0b1fc2e0c275b8a6aceeb155a68861f63f87a798f16/multidict-6.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:23bfeee5316266e5ee2d625df2d2c602b829435fc3a235c2ba2131495706e4a0", size = 239245, upload-time = "2025-10-06T14:48:41.848Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/75fa96394478930b79d0302eaf9a6c69f34005a1a5251ac8b9c336486ec9/multidict-6.7.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:680878b9f3d45c31e1f730eef731f9b0bc1da456155688c6745ee84eb818e90e", size = 233523, upload-time = "2025-10-06T14:48:43.749Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5e/085544cb9f9c4ad2b5d97467c15f856df8d9bac410cffd5c43991a5d878b/multidict-6.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:eb866162ef2f45063acc7a53a88ef6fe8bf121d45c30ea3c9cd87ce7e191a8d4", size = 243129, upload-time = "2025-10-06T14:48:45.225Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c3/e9d9e2f20c9474e7a8fcef28f863c5cbd29bb5adce6b70cebe8bdad0039d/multidict-6.7.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:df0e3bf7993bdbeca5ac25aa859cf40d39019e015c9c91809ba7093967f7a648", size = 248999, upload-time = "2025-10-06T14:48:46.703Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3f/df171b6efa3239ae33b97b887e42671cd1d94d460614bfb2c30ffdab3b95/multidict-6.7.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:661709cdcd919a2ece2234f9bae7174e5220c80b034585d7d8a755632d3e2111", size = 243711, upload-time = "2025-10-06T14:48:48.146Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2f/9b5564888c4e14b9af64c54acf149263721a283aaf4aa0ae89b091d5d8c1/multidict-6.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:096f52730c3fb8ed419db2d44391932b63891b2c5ed14850a7e215c0ba9ade36", size = 237504, upload-time = "2025-10-06T14:48:49.447Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/3a/0bd6ca0f7d96d790542d591c8c3354c1e1b6bfd2024d4d92dc3d87485ec7/multidict-6.7.0-cp310-cp310-win32.whl", hash = "sha256:afa8a2978ec65d2336305550535c9c4ff50ee527914328c8677b3973ade52b85", size = 41422, upload-time = "2025-10-06T14:48:50.789Z" },
+    { url = "https://files.pythonhosted.org/packages/00/35/f6a637ea2c75f0d3b7c7d41b1189189acff0d9deeb8b8f35536bb30f5e33/multidict-6.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:b15b3afff74f707b9275d5ba6a91ae8f6429c3ffb29bbfd216b0b375a56f13d7", size = 46050, upload-time = "2025-10-06T14:48:51.938Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b8/f7bf8329b39893d02d9d95cf610c75885d12fc0f402b1c894e1c8e01c916/multidict-6.7.0-cp310-cp310-win_arm64.whl", hash = "sha256:4b73189894398d59131a66ff157837b1fafea9974be486d036bb3d32331fdbf0", size = 43153, upload-time = "2025-10-06T14:48:53.146Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
+]
+
+[[package]]
+name = "nose"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz", hash = "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98", size = 280488, upload-time = "2015-06-02T09:12:32.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl", hash = "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac", size = 154731, upload-time = "2015-06-02T09:12:40.57Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/b3/b13bce39ba82b7398c06d10446f5ffd5c07db39b09bd37370dc720c7951c/numpy-1.26.0.tar.gz", hash = "sha256:f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf", size = 15633455, upload-time = "2023-09-16T20:12:58.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f8/034752c5131c46e10364e4db241974f2eb6bb31bbfc4335344c19e17d909/numpy-1.26.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8db2f125746e44dce707dd44d4f4efeea8d7e2b43aace3f8d1f235cfa2733dd", size = 20617359, upload-time = "2023-09-16T19:58:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ff/0e1f31c70495df6a1afbe98fa237f36e6fb7c5443fcb9a53f43170e5814c/numpy-1.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0621f7daf973d34d18b4e4bafb210bbaf1ef5e0100b5fa750bd9cde84c7ac292", size = 13953220, upload-time = "2023-09-16T19:58:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c7/dc05fb56c0536f499d75ef4e201c37facb75e1ad1f416b98a9939f89f6f1/numpy-1.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51be5f8c349fdd1a5568e72713a21f518e7d6707bcf8503b528b88d33b57dc68", size = 14167853, upload-time = "2023-09-16T19:59:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5a/f265a1ba3641d16b5480a217a6aed08cceef09cd173b568cd5351053472a/numpy-1.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:767254ad364991ccfc4d81b8152912e53e103ec192d1bb4ea6b1f5a7117040be", size = 18181958, upload-time = "2023-09-16T19:59:30.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cc/be866f190cfe818e1eb128f887b3cd715cfa554de9d5fe876c5a3ea3af48/numpy-1.26.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:436c8e9a4bdeeee84e3e59614d38c3dbd3235838a877af8c211cfcac8a80b8d3", size = 18025005, upload-time = "2023-09-16T19:59:59.382Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/16/bb4ff6c803f3000c130618f75a879fc335c9f9434d1317033c35876709ca/numpy-1.26.0-cp310-cp310-win32.whl", hash = "sha256:c2e698cb0c6dda9372ea98a0344245ee65bdc1c9dd939cceed6bb91256837896", size = 20745239, upload-time = "2023-09-16T20:00:33.545Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/05/ef9fc04adda45d537619ea956bc33489f50a46badc949c4280d8309185ec/numpy-1.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:09aaee96c2cbdea95de76ecb8a586cb687d281c881f5f17bfc0fb7f5890f6b91", size = 15793269, upload-time = "2023-09-16T20:00:59.079Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.3.20"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openai"
+version = "1.109.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/bcd1e5500de6ec794c085a277e5b624e60b4fac1790681d7cdbde25b93a2/optuna-4.5.0.tar.gz", hash = "sha256:264844da16dad744dea295057d8bc218646129c47567d52c35a201d9f99942ba", size = 472338, upload-time = "2025-08-18T06:49:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/12/cba81286cbaf0f0c3f0473846cfd992cb240bdcea816bf2ef7de8ed0f744/optuna-4.5.0-py3-none-any.whl", hash = "sha256:5b8a783e84e448b0742501bc27195344a28d2c77bd2feef5b558544d954851b0", size = 400872, upload-time = "2025-08-18T06:49:20.697Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fe/ed708782d6709cc60eb4c2d8a361a440661f74134675c72990f2c48c785f/orjson-3.11.4.tar.gz", hash = "sha256:39485f4ab4c9b30a3943cfe99e1a213c4776fb69e8abd68f66b83d5a0b0fdc6d", size = 5945188, upload-time = "2025-10-24T15:50:38.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/30/5aed63d5af1c8b02fbd2a8d83e2a6c8455e30504c50dbf08c8b51403d873/orjson-3.11.4-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e3aa2118a3ece0d25489cbe48498de8a5d580e42e8d9979f65bf47900a15aba1", size = 243870, upload-time = "2025-10-24T15:48:28.908Z" },
+    { url = "https://files.pythonhosted.org/packages/44/1f/da46563c08bef33c41fd63c660abcd2184b4d2b950c8686317d03b9f5f0c/orjson-3.11.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a69ab657a4e6733133a3dca82768f2f8b884043714e8d2b9ba9f52b6efef5c44", size = 130622, upload-time = "2025-10-24T15:48:31.361Z" },
+    { url = "https://files.pythonhosted.org/packages/02/bd/b551a05d0090eab0bf8008a13a14edc0f3c3e0236aa6f5b697760dd2817b/orjson-3.11.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3740bffd9816fc0326ddc406098a3a8f387e42223f5f455f2a02a9f834ead80c", size = 129344, upload-time = "2025-10-24T15:48:32.71Z" },
+    { url = "https://files.pythonhosted.org/packages/87/6c/9ddd5e609f443b2548c5e7df3c44d0e86df2c68587a0e20c50018cdec535/orjson-3.11.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65fd2f5730b1bf7f350c6dc896173d3460d235c4be007af73986d7cd9a2acd23", size = 136633, upload-time = "2025-10-24T15:48:34.128Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f2/9f04f2874c625a9fb60f6918c33542320661255323c272e66f7dcce14df2/orjson-3.11.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fdc3ae730541086158d549c97852e2eea6820665d4faf0f41bf99df41bc11ea", size = 137695, upload-time = "2025-10-24T15:48:35.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c2/c7302afcbdfe8a891baae0e2cee091583a30e6fa613e8bdf33b0e9c8a8c7/orjson-3.11.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e10b4d65901da88845516ce9f7f9736f9638d19a1d483b3883dc0182e6e5edba", size = 136879, upload-time = "2025-10-24T15:48:37.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3a/b31c8f0182a3e27f48e703f46e61bb769666cd0dac4700a73912d07a1417/orjson-3.11.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb6a03a678085f64b97f9d4a9ae69376ce91a3a9e9b56a82b1580d8e1d501aff", size = 136374, upload-time = "2025-10-24T15:48:38.624Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d0/fd9ab96841b090d281c46df566b7f97bc6c8cd9aff3f3ebe99755895c406/orjson-3.11.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2c82e4f0b1c712477317434761fbc28b044c838b6b1240d895607441412371ac", size = 140519, upload-time = "2025-10-24T15:48:39.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ce/36eb0f15978bb88e33a3480e1a3fb891caa0f189ba61ce7713e0ccdadabf/orjson-3.11.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:d58c166a18f44cc9e2bad03a327dc2d1a3d2e85b847133cfbafd6bfc6719bd79", size = 406522, upload-time = "2025-10-24T15:48:41.198Z" },
+    { url = "https://files.pythonhosted.org/packages/85/11/e8af3161a288f5c6a00c188fc729c7ba193b0cbc07309a1a29c004347c30/orjson-3.11.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:94f206766bf1ea30e1382e4890f763bd1eefddc580e08fec1ccdc20ddd95c827", size = 149790, upload-time = "2025-10-24T15:48:42.664Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/96/209d52db0cf1e10ed48d8c194841e383e23c2ced5a2ee766649fe0e32d02/orjson-3.11.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:41bf25fb39a34cf8edb4398818523277ee7096689db352036a9e8437f2f3ee6b", size = 140040, upload-time = "2025-10-24T15:48:44.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/0e/526db1395ccb74c3d59ac1660b9a325017096dc5643086b38f27662b4add/orjson-3.11.4-cp310-cp310-win32.whl", hash = "sha256:fa9627eba4e82f99ca6d29bc967f09aba446ee2b5a1ea728949ede73d313f5d3", size = 135955, upload-time = "2025-10-24T15:48:45.495Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/69/18a778c9de3702b19880e73c9866b91cc85f904b885d816ba1ab318b223c/orjson-3.11.4-cp310-cp310-win_amd64.whl", hash = "sha256:23ef7abc7fca96632d8174ac115e668c1e931b8fe4dde586e92a500bf1914dcc", size = 131577, upload-time = "2025-10-24T15:48:46.609Z" },
+]
+
+[[package]]
+name = "outlines"
+version = "1.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "diskcache" },
+    { name = "genson" },
+    { name = "jinja2" },
+    { name = "jsonpath-ng" },
+    { name = "jsonschema" },
+    { name = "outlines-core" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/11/e2a0d3c3a8b79a9dd7f69060927e91d6ffa3e9b9a3f6b05ba3501f2a2d63/outlines-1.2.8.tar.gz", hash = "sha256:acd479f440f8e14ceb98bf453ac39ca25d338a7540b72eb1ab93710e3514a64c", size = 2883833, upload-time = "2025-10-27T11:00:59.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7f/f5a517105a8367245f6286a3fd42ddc5fe7e7b6cb650a3fe7c7590b71c7a/outlines-1.2.8-py3-none-any.whl", hash = "sha256:d88a479346c7af4ba26a2d3743a3d95a11e1b013d68603a37f2da414af47248f", size = 98306, upload-time = "2025-10-27T11:00:58.443Z" },
+]
+
+[[package]]
+name = "outlines-core"
+version = "0.2.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/d3/e04e9145f8f806723dec9b9e5227ad695a3efcd3ced7794cf7c22b15df5e/outlines_core-0.2.11.tar.gz", hash = "sha256:dfce56f717ff5083e54cbcfdb66cad243365437fccbb5509adaa7e31e030f1d8", size = 197263, upload-time = "2025-05-19T10:12:51.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/8f/83c83e2afd142067c7f3cf2e152809195eee72d6a9b6c8745f13b827273d/outlines_core-0.2.11-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:89d79d8454b321f60047541a896d410ca9db631d241960266c4fe839cf5cd1b1", size = 1961650, upload-time = "2025-05-19T10:11:53.12Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e9/c6b99b4364b7026b71badc06b9809a2fc4154d6b0c475bc03ab4471f81e5/outlines_core-0.2.11-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:44d581893f8644da02db7be11887229a40d26077cbdd22072ad1ed1db0ad0b2d", size = 2133920, upload-time = "2025-05-19T10:11:55.15Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b8/cfa2bd8e1260eb1870c42a1a34389e9673a12335d09004ea6f1c82266a5e/outlines_core-0.2.11-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:e88b7f717915d91136d915adb65c2603d2aa6457ec3fc336884bdb0b28d3188a", size = 1960688, upload-time = "2025-05-19T10:11:56.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/02/4cffd04e360e315b060692bf1a80f84bac1671ef90f12daf765db6d68791/outlines_core-0.2.11-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8c7ecdba2162e9b30b837251387c26b1a23f80f58d01d02e7600e4b1962c5333", size = 2130263, upload-time = "2025-05-19T10:11:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/85/69a450a486824026eca181a8d573aae3ecfdb25f0c2af852065dde17a372/outlines_core-0.2.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd5fcefd221c10c95ce74838869450c6fdbbe2f581f0ba27e57a95232bd88c3a", size = 2289453, upload-time = "2025-05-19T10:11:59.919Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3c/d7cb3eac6870a68b9034854fbfa07e67abfa1fa0d92198b9fee83fe6d044/outlines_core-0.2.11-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a3c7774b112106f3afe931c65637fb3e0725d43707ceff1d34d6899cf0fa8200", size = 2115289, upload-time = "2025-05-19T10:12:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5f/4cef22e2cf1ec286bd78c0052a0fa7ecf8519144477e7d4e276cbd70c625/outlines_core-0.2.11-cp310-cp310-win32.whl", hash = "sha256:1cfbb4cdcf34be5c6b08d279928b2b1050ed4c5e96e6e8405e3e624305c6799e", size = 1768059, upload-time = "2025-05-19T10:12:03.058Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3a/ce6aceb6545bb1e13cf05c1f34468c5c14c8c8be92cdabcf777b4bb067ef/outlines_core-0.2.11-cp310-cp310-win_amd64.whl", hash = "sha256:670c1c1fca26fb5c7f00dbb11d1f81cca4204863c3dfdeee82017a6846397bf9", size = 2062413, upload-time = "2025-05-19T10:12:05.097Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/70/c853aec59839bceed032d52010ff5f1b8d87dc3114b762e4ba2727661a3b/pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5", size = 12580827, upload-time = "2024-09-20T13:08:42.347Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f2/c4527768739ffa4469b2b4fff05aa3768a478aed89a2f271a79a40eee984/pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348", size = 11303897, upload-time = "2024-09-20T13:08:45.807Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/12/86c1747ea27989d7a4064f806ce2bae2c6d575b950be087837bdfcabacc9/pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed", size = 66480908, upload-time = "2024-09-20T18:37:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/44/50/7db2cd5e6373ae796f0ddad3675268c8d59fb6076e66f0c339d61cea886b/pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57", size = 13064210, upload-time = "2024-09-20T13:08:48.325Z" },
+    { url = "https://files.pythonhosted.org/packages/61/61/a89015a6d5536cb0d6c3ba02cebed51a95538cf83472975275e28ebf7d0c/pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42", size = 16754292, upload-time = "2024-09-20T19:01:54.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/4cc7b69ce37fac07645a94e1d4b0880b15999494372c1523508511b09e40/pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f", size = 14416379, upload-time = "2024-09-20T13:08:50.882Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9e/6ebb433de864a6cd45716af52a4d7a8c3c9aaf3a98368e61db9e69e69a9c/pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645", size = 11598471, upload-time = "2024-09-20T13:08:53.332Z" },
+]
+
+[[package]]
+name = "partd"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "locket" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pendulum"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/7c/009c12b86c7cc6c403aec80f8a4308598dfc5995e5c523a5491faaa3952e/pendulum-3.1.0.tar.gz", hash = "sha256:66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015", size = 85930, upload-time = "2025-04-19T14:30:01.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/d8/398cd27903a6899d0ae47b896d88e0b15849fc334931a6732e7ce3be9a45/pendulum-3.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:aa545a59e6517cf43597455a6fb44daa4a6e08473d67a7ad34e4fa951efb9620", size = 338637, upload-time = "2025-04-19T14:00:56.429Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9d/a125554919c6db14e189393254c7781ee98ed5a121b6c05652d353b03c12/pendulum-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:299df2da6c490ede86bb8d58c65e33d7a2a42479d21475a54b467b03ccb88531", size = 326003, upload-time = "2025-04-19T14:00:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/53/9f/43a5a902f904e06252c259c2f6cf2dceafbb25aef158df08f79c0089dfd7/pendulum-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbaa66e3ab179a2746eec67462f852a5d555bd709c25030aef38477468dd008e", size = 344335, upload-time = "2025-04-19T14:00:59.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/24/00fcd6abd1f7623d2bbcca048b45f01aa8bb6b647e0477c3a8ea6094335c/pendulum-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3907ab3744c32e339c358d88ec80cd35fa2d4b25c77a3c67e6b39e99b7090c5", size = 382169, upload-time = "2025-04-19T14:01:01.411Z" },
+    { url = "https://files.pythonhosted.org/packages/32/bc/20a87f24c26c6c4daf3c69311208b28130b4d19c006da16efc0e55715963/pendulum-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8244958c5bc4ed1c47ee84b098ddd95287a3fc59e569ca6e2b664c6396138ec4", size = 436675, upload-time = "2025-04-19T14:01:03.068Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/eb/3b1818a796408a250b8e6cfaa5372b991c0cbec768e02e0f9a226755383d/pendulum-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca5722b3993b85ff7dfced48d86b318f863c359877b6badf1a3601e35199ef8f", size = 353728, upload-time = "2025-04-19T14:01:04.483Z" },
+    { url = "https://files.pythonhosted.org/packages/36/23/755ef61f863b2777925171a59509540205b561a9e07ee7de0b5be9226bea/pendulum-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5b77a3dc010eea1a4916ef3771163d808bfc3e02b894c37df311287f18e5b764", size = 524465, upload-time = "2025-04-19T14:01:05.865Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1f/a3e5f08890d13d93eee725778bfeaa233db5c55463e526857dffbc1a47e4/pendulum-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2d6e1eff4a15fdb8fb3867c5469e691c2465eef002a6a541c47b48a390ff4cf4", size = 525690, upload-time = "2025-04-19T14:01:07.707Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c5/bf8ce472b81e8f5f074e8ba39899d288acce417c2c4a9ec7486d56970e28/pendulum-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:73de43ec85b46ac75db848c8e2f3f5d086e90b11cd9c7f029e14c8d748d920e2", size = 260356, upload-time = "2025-04-19T14:01:09.339Z" },
+    { url = "https://files.pythonhosted.org/packages/66/10/3258c084653606d2be2c7168998eda4a57cf1559cecb43cf1100000fda5f/pendulum-3.1.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d2cac744940299d8da41a3ed941aa1e02b5abbc9ae2c525f3aa2ae30c28a86b5", size = 339442, upload-time = "2025-04-19T14:02:12.512Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d5/98a1a10cd1cfb3390fbf070864e9a10de8e70a9d4509832132f4d900d655/pendulum-3.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:ffb39c3f3906a9c9a108fa98e5556f18b52d2c6451984bbfe2f14436ec4fc9d4", size = 326609, upload-time = "2025-04-19T14:02:13.838Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/2e/448abdebc11b9c54e190d273cb084162643199fc184cb1bb6bff7900e67f/pendulum-3.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe18b1c2eb364064cc4a68a65900f1465cac47d0891dab82341766bcc05b40c", size = 344777, upload-time = "2025-04-19T14:02:15.512Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/91/ee857bbd51168bf08b89c3a4705c920725eee0f830ccc513b8370f6ce71d/pendulum-3.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9e9b28a35cec9fcd90f224b4878456129a057dbd694fc8266a9393834804995", size = 354404, upload-time = "2025-04-19T14:02:16.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d4/e63a57df65e2b2d10f3aa917a4069be9abf5ac7d56d11336e0510742d8a6/pendulum-3.1.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a3be19b73a9c6a866724419295482f817727e635ccc82f07ae6f818943a1ee96", size = 524948, upload-time = "2025-04-19T14:02:18.808Z" },
+    { url = "https://files.pythonhosted.org/packages/93/87/04e74600c5a5674e5f341b8888b530a9de9b84b31889f80fac3bee3e9e87/pendulum-3.1.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:24a53b523819bda4c70245687a589b5ea88711f7caac4be5f276d843fe63076b", size = 526340, upload-time = "2025-04-19T14:02:20.242Z" },
+    { url = "https://files.pythonhosted.org/packages/48/27/d3577a5f6f7d1fbf1138d87ce21ebab363c78642513b991d1c424d658d09/pendulum-3.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:bd701789414fbd0be3c75f46803f31e91140c23821e4bcb0fa2bddcdd051c425", size = 261089, upload-time = "2025-04-19T14:02:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/23/e98758924d1b3aac11a626268eabf7f3cf177e7837c28d47bf84c64532d0/pendulum-3.1.0-py3-none-any.whl", hash = "sha256:f9178c2a8e291758ade1e8dd6371b1d26d08371b4c7730a6e9a3ef8b16ebae0f", size = 111799, upload-time = "2025-04-19T14:02:34.739Z" },
+]
+
+[[package]]
+name = "pengines"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a3/fd7e21f2d00d6eb6f6a6e932f6479149ce01265f125b203942cdfcac9089/pengines-0.1.8.tar.gz", hash = "sha256:5325205eaa538f0c02ec886ff5bfd031949e141d0459479817173ec99a6c9d95", size = 8149, upload-time = "2019-08-12T21:39:27.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/de/fab4d98642b805839e7d7779780a1c567db61f1a0f8829686b55e1d265f8/pengines-0.1.8-py3-none-any.whl", hash = "sha256:35ea10b7d2c77757b2a97160298c5d28b4145b00635005647afecdbf5a47763b", size = 9205, upload-time = "2019-08-12T21:39:24.76Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/cace85a1b0c9775a9f8f5d5423c8261c858760e2466c79b2dd184638b056/pillow-12.0.0.tar.gz", hash = "sha256:87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353", size = 47008828, upload-time = "2025-10-15T18:24:14.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/08/26e68b6b5da219c2a2cb7b563af008b53bb8e6b6fcb3fa40715fcdb2523a/pillow-12.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:3adfb466bbc544b926d50fe8f4a4e6abd8c6bffd28a26177594e6e9b2b76572b", size = 5289809, upload-time = "2025-10-15T18:21:27.791Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/4e58fb097fb74c7b4758a680aacd558810a417d1edaa7000142976ef9d2f/pillow-12.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1ac11e8ea4f611c3c0147424eae514028b5e9077dd99ab91e1bd7bc33ff145e1", size = 4650606, upload-time = "2025-10-15T18:21:29.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e0/1fa492aa9f77b3bc6d471c468e62bfea1823056bf7e5e4f1914d7ab2565e/pillow-12.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d49e2314c373f4c2b39446fb1a45ed333c850e09d0c59ac79b72eb3b95397363", size = 6221023, upload-time = "2025-10-15T18:21:31.415Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/09/4de7cd03e33734ccd0c876f0251401f1314e819cbfd89a0fcb6e77927cc6/pillow-12.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7b2a63fd6d5246349f3d3f37b14430d73ee7e8173154461785e43036ffa96ca", size = 8024937, upload-time = "2025-10-15T18:21:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/69/0688e7c1390666592876d9d474f5e135abb4acb39dcb583c4dc5490f1aff/pillow-12.0.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d64317d2587c70324b79861babb9c09f71fbb780bad212018874b2c013d8600e", size = 6334139, upload-time = "2025-10-15T18:21:35.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1c/880921e98f525b9b44ce747ad1ea8f73fd7e992bafe3ca5e5644bf433dea/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d77153e14b709fd8b8af6f66a3afbb9ed6e9fc5ccf0b6b7e1ced7b036a228782", size = 7026074, upload-time = "2025-10-15T18:21:37.219Z" },
+    { url = "https://files.pythonhosted.org/packages/28/03/96f718331b19b355610ef4ebdbbde3557c726513030665071fd025745671/pillow-12.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:32ed80ea8a90ee3e6fa08c21e2e091bba6eda8eccc83dbc34c95169507a91f10", size = 6448852, upload-time = "2025-10-15T18:21:39.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a0/6a193b3f0cc9437b122978d2c5cbce59510ccf9a5b48825096ed7472da2f/pillow-12.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c828a1ae702fc712978bda0320ba1b9893d99be0badf2647f693cc01cf0f04fa", size = 7117058, upload-time = "2025-10-15T18:21:40.997Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c4/043192375eaa4463254e8e61f0e2ec9a846b983929a8d0a7122e0a6d6fff/pillow-12.0.0-cp310-cp310-win32.whl", hash = "sha256:bd87e140e45399c818fac4247880b9ce719e4783d767e030a883a970be632275", size = 6295431, upload-time = "2025-10-15T18:21:42.518Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c6/c2f2fc7e56301c21827e689bb8b0b465f1b52878b57471a070678c0c33cd/pillow-12.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:455247ac8a4cfb7b9bc45b7e432d10421aea9fc2e74d285ba4072688a74c2e9d", size = 7000412, upload-time = "2025-10-15T18:21:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d2/5f675067ba82da7a1c238a73b32e3fd78d67f9d9f80fbadd33a40b9c0481/pillow-12.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:6ace95230bfb7cd79ef66caa064bbe2f2a1e63d93471c3a2e1f1348d9f22d6b7", size = 2435903, upload-time = "2025-10-15T18:21:46.29Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/5b/3caad788d93304026cbf0ab4c37f8402058b64a2f153b9c62f8b30f5d2ee/polars-1.35.1.tar.gz", hash = "sha256:06548e6d554580151d6ca7452d74bceeec4640b5b9261836889b8e68cfd7a62e", size = 694881, upload-time = "2025-10-30T12:12:52.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4c/21a227b722534404241c2a76beceb7463469d50c775a227fc5c209eb8adc/polars-1.35.1-py3-none-any.whl", hash = "sha256:c29a933f28aa330d96a633adbd79aa5e6a6247a802a720eead9933f4613bdbf4", size = 783598, upload-time = "2025-10-30T12:11:54.668Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/3e/19c252e8eb4096300c1a36ec3e50a27e5fa9a1ccaf32d3927793c16abaee/polars_runtime_32-1.35.1.tar.gz", hash = "sha256:f6b4ec9cd58b31c87af1b8c110c9c986d82345f1d50d7f7595b5d447a19dc365", size = 2696218, upload-time = "2025-10-30T12:12:53.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/2c/da339459805a26105e9d9c2f07e43ca5b8baeee55acd5457e6881487a79a/polars_runtime_32-1.35.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6f051a42f6ae2f26e3bc2cf1f170f2120602976e2a3ffb6cfba742eecc7cc620", size = 40525100, upload-time = "2025-10-30T12:11:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/a0733568b3533481924d2ce68b279ab3d7334e5fa6ed259f671f650b7c5e/polars_runtime_32-1.35.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c2232f9cf05ba59efc72d940b86c033d41fd2d70bf2742e8115ed7112a766aa9", size = 36701908, upload-time = "2025-10-30T12:12:02.166Z" },
+    { url = "https://files.pythonhosted.org/packages/46/54/6c09137bef9da72fd891ba58c2962cc7c6c5cad4649c0e668d6b344a9d7b/polars_runtime_32-1.35.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42f9837348557fd674477ea40a6ac8a7e839674f6dd0a199df24be91b026024c", size = 41317692, upload-time = "2025-10-30T12:12:04.928Z" },
+    { url = "https://files.pythonhosted.org/packages/22/55/81c5b266a947c339edd7fbaa9e1d9614012d02418453f48b76cc177d3dd9/polars_runtime_32-1.35.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:c873aeb36fed182d5ebc35ca17c7eb193fe83ae2ea551ee8523ec34776731390", size = 37853058, upload-time = "2025-10-30T12:12:08.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/be8b034d559eac515f52408fd6537be9bea095bc0388946a4e38910d3d50/polars_runtime_32-1.35.1-cp39-abi3-win_amd64.whl", hash = "sha256:35cde9453ca7032933f0e58e9ed4388f5a1e415dd0db2dd1e442c81d815e630c", size = 41289554, upload-time = "2025-10-30T12:12:11.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7f/e0111b9e2a1169ea82cde3ded9c92683e93c26dfccd72aee727996a1ac5b/polars_runtime_32-1.35.1-cp39-abi3-win_arm64.whl", hash = "sha256:fd77757a6c9eb9865c4bfb7b07e22225207c6b7da382bd0b9bd47732f637105d", size = 36958878, upload-time = "2025-10-30T12:12:15.206Z" },
+]
+
+[[package]]
+name = "prefect"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "anyio" },
+    { name = "apprise" },
+    { name = "asgi-lifespan" },
+    { name = "asyncpg" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "coolname" },
+    { name = "cryptography" },
+    { name = "dateparser" },
+    { name = "docker" },
+    { name = "exceptiongroup" },
+    { name = "fastapi" },
+    { name = "fsspec" },
+    { name = "graphviz" },
+    { name = "griffe" },
+    { name = "httpcore" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "humanize" },
+    { name = "jinja2" },
+    { name = "jinja2-humanize-extension" },
+    { name = "jsonpatch" },
+    { name = "jsonschema" },
+    { name = "opentelemetry-api" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pendulum" },
+    { name = "pluggy" },
+    { name = "prometheus-client" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-dateutil" },
+    { name = "python-slugify" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "readchar" },
+    { name = "rfc3339-validator" },
+    { name = "rich" },
+    { name = "ruamel-yaml" },
+    { name = "semver" },
+    { name = "sniffio" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "uv" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e3/3869249b4defe65986cb323f11d17ac1fba13a214fc577f8f4e7e3ce45e2/prefect-3.5.0.tar.gz", hash = "sha256:05acf33be811fe62dcc7eb65cac3cc27372a99cb545342d260bd1831933256b8", size = 5633886, upload-time = "2025-10-31T18:03:58.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/e6/96494debc7f5fb9730a75abfa600efaeac7fa40683ba52b478f0df294ee8/prefect-3.5.0-py3-none-any.whl", hash = "sha256:587da2323c609877f3d89adce970a603a12314516e111e3e0fbfb7a4ef9ef390", size = 6158049, upload-time = "2025-10-31T18:03:55.596Z" },
+]
+
+[[package]]
+name = "progressbar33"
+version = "2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/fc/7c8e01f41a6e671d7b11be470eeb3d15339c75ce5559935f3f55890eec6b/progressbar33-2.4.tar.gz", hash = "sha256:51fe0d9b3b4023db2f983eeccdfc8c9846b84db8443b9bee002c7f58f4376eff", size = 10184, upload-time = "2014-08-29T08:55:20.581Z" }
+
+[[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/0e/934b541323035566a9af292dba85a195f7b78179114f2c6ebb24551118a9/propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db", size = 79534, upload-time = "2025-10-08T19:46:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6b/db0d03d96726d995dc7171286c6ba9d8d14251f37433890f88368951a44e/propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8", size = 45526, upload-time = "2025-10-08T19:46:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c3/82728404aea669e1600f304f2609cde9e665c18df5a11cdd57ed73c1dceb/propcache-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:66c1f011f45a3b33d7bcb22daed4b29c0c9e2224758b6be00686731e1b46f925", size = 47263, upload-time = "2025-10-08T19:46:05.405Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1b/39313ddad2bf9187a1432654c38249bab4562ef535ef07f5eb6eb04d0b1b/propcache-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a52009f2adffe195d0b605c25ec929d26b36ef986ba85244891dee3b294df21", size = 201012, upload-time = "2025-10-08T19:46:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/f1d0b57d136f294a142acf97f4ed58c8e5b974c21e543000968357115011/propcache-0.4.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d4e2366a9c7b837555cf02fb9be2e3167d333aff716332ef1b7c3a142ec40c5", size = 209491, upload-time = "2025-10-08T19:46:08.909Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c8/038d909c61c5bb039070b3fb02ad5cccdb1dde0d714792e251cdb17c9c05/propcache-0.4.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9d2b6caef873b4f09e26ea7e33d65f42b944837563a47a94719cc3544319a0db", size = 215319, upload-time = "2025-10-08T19:46:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/08/57/8c87e93142b2c1fa2408e45695205a7ba05fb5db458c0bf5c06ba0e09ea6/propcache-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b16ec437a8c8a965ecf95739448dd938b5c7f56e67ea009f4300d8df05f32b7", size = 196856, upload-time = "2025-10-08T19:46:12.003Z" },
+    { url = "https://files.pythonhosted.org/packages/42/df/5615fec76aa561987a534759b3686008a288e73107faa49a8ae5795a9f7a/propcache-0.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:296f4c8ed03ca7476813fe666c9ea97869a8d7aec972618671b33a38a5182ef4", size = 193241, upload-time = "2025-10-08T19:46:13.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/62949eb3a7a54afe8327011c90aca7e03547787a88fb8bd9726806482fea/propcache-0.4.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1f0978529a418ebd1f49dad413a2b68af33f85d5c5ca5c6ca2a3bed375a7ac60", size = 190552, upload-time = "2025-10-08T19:46:14.938Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ee/ab4d727dd70806e5b4de96a798ae7ac6e4d42516f030ee60522474b6b332/propcache-0.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fd138803047fb4c062b1c1dd95462f5209456bfab55c734458f15d11da288f8f", size = 200113, upload-time = "2025-10-08T19:46:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/38b46208e6711b016aa8966a3ac793eee0d05c7159d8342aa27fc0bc365e/propcache-0.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8c9b3cbe4584636d72ff556d9036e0c9317fa27b3ac1f0f558e7e84d1c9c5900", size = 200778, upload-time = "2025-10-08T19:46:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/81/5abec54355ed344476bee711e9f04815d4b00a311ab0535599204eecc257/propcache-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f93243fdc5657247533273ac4f86ae106cc6445a0efacb9a1bfe982fcfefd90c", size = 193047, upload-time = "2025-10-08T19:46:19.449Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b6/1f237c04e32063cb034acd5f6ef34ef3a394f75502e72703545631ab1ef6/propcache-0.4.1-cp310-cp310-win32.whl", hash = "sha256:a0ee98db9c5f80785b266eb805016e36058ac72c51a064040f2bc43b61101cdb", size = 38093, upload-time = "2025-10-08T19:46:20.643Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/67/354aac4e0603a15f76439caf0427781bcd6797f370377f75a642133bc954/propcache-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:1cdb7988c4e5ac7f6d175a28a9aa0c94cb6f2ebe52756a3c0cda98d2809a9e37", size = 41638, upload-time = "2025-10-08T19:46:21.935Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e1/74e55b9fd1a4c209ff1a9a824bf6c8b3d1fc5a1ac3eabe23462637466785/propcache-0.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:d82ad62b19645419fe79dd63b3f9253e15b30e955c0170e5cebc350c1844e581", size = 38229, upload-time = "2025-10-08T19:46:23.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/88/bdd0a41e5857d5d703287598cbf08dad90aed56774ea52ae071bae9071b6/psutil-7.1.3.tar.gz", hash = "sha256:6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74", size = 489059, upload-time = "2025-11-02T12:25:54.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/94/46b9154a800253e7ecff5aaacdf8ebf43db99de4a2dfa18575b02548654e/psutil-7.1.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2bdbcd0e58ca14996a42adf3621a6244f1bb2e2e528886959c72cf1e326677ab", size = 238359, upload-time = "2025-11-02T12:26:25.284Z" },
+    { url = "https://files.pythonhosted.org/packages/68/3a/9f93cff5c025029a36d9a92fef47220ab4692ee7f2be0fba9f92813d0cb8/psutil-7.1.3-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc31fa00f1fbc3c3802141eede66f3a2d51d89716a194bf2cd6fc68310a19880", size = 239171, upload-time = "2025-11-02T12:26:27.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b1/5f49af514f76431ba4eea935b8ad3725cdeb397e9245ab919dbc1d1dc20f/psutil-7.1.3-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb428f9f05c1225a558f53e30ccbad9930b11c3fc206836242de1091d3e7dd3", size = 263261, upload-time = "2025-11-02T12:26:29.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "22.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/9b/cb3f7e0a345353def531ca879053e9ef6b9f38ed91aebcf68b09ba54dec0/pyarrow-22.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:77718810bd3066158db1e95a63c160ad7ce08c6b0710bc656055033e39cdad88", size = 34223968, upload-time = "2025-10-24T10:03:31.21Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/41/3184b8192a120306270c5307f105b70320fdaa592c99843c5ef78aaefdcf/pyarrow-22.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:44d2d26cda26d18f7af7db71453b7b783788322d756e81730acb98f24eb90ace", size = 35942085, upload-time = "2025-10-24T10:03:38.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3d/a1eab2f6f08001f9fb714b8ed5cfb045e2fe3e3e3c0c221f2c9ed1e6d67d/pyarrow-22.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b9d71701ce97c95480fecb0039ec5bb889e75f110da72005743451339262f4ce", size = 44964613, upload-time = "2025-10-24T10:03:46.516Z" },
+    { url = "https://files.pythonhosted.org/packages/46/46/a1d9c24baf21cfd9ce994ac820a24608decf2710521b29223d4334985127/pyarrow-22.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:710624ab925dc2b05a6229d47f6f0dac1c1155e6ed559be7109f684eba048a48", size = 47627059, upload-time = "2025-10-24T10:03:55.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/4c/f711acb13075c1391fd54bc17e078587672c575f8de2a6e62509af026dcf/pyarrow-22.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f963ba8c3b0199f9d6b794c90ec77545e05eadc83973897a4523c9e8d84e9340", size = 47947043, upload-time = "2025-10-24T10:04:05.408Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/70/1f3180dd7c2eab35c2aca2b29ace6c519f827dcd4cfeb8e0dca41612cf7a/pyarrow-22.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bd0d42297ace400d8febe55f13fdf46e86754842b860c978dfec16f081e5c653", size = 50206505, upload-time = "2025-10-24T10:04:15.786Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/fea6578112c8c60ffde55883a571e4c4c6bc7049f119d6b09333b5cc6f73/pyarrow-22.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:00626d9dc0f5ef3a75fe63fd68b9c7c8302d2b5bbc7f74ecaedba83447a24f84", size = 28101641, upload-time = "2025-10-24T10:04:22.57Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/3d/9b8ca77b0f76fcdbf8bc6b72474e264283f461284ca84ac3fde570c6c49a/pydantic_core-2.41.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2442d9a4d38f3411f22eb9dd0912b7cbf4b7d5b6c92c4173b75d3e1ccd84e36e", size = 2111197, upload-time = "2025-10-14T10:19:43.303Z" },
+    { url = "https://files.pythonhosted.org/packages/59/92/b7b0fe6ed4781642232755cb7e56a86e2041e1292f16d9ae410a0ccee5ac/pydantic_core-2.41.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30a9876226dda131a741afeab2702e2d127209bde3c65a2b8133f428bc5d006b", size = 1917909, upload-time = "2025-10-14T10:19:45.194Z" },
+    { url = "https://files.pythonhosted.org/packages/52/8c/3eb872009274ffa4fb6a9585114e161aa1a0915af2896e2d441642929fe4/pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d55bbac04711e2980645af68b97d445cdbcce70e5216de444a6c4b6943ebcccd", size = 1969905, upload-time = "2025-10-14T10:19:46.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/21/35adf4a753bcfaea22d925214a0c5b880792e3244731b3f3e6fec0d124f7/pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1d778fb7849a42d0ee5927ab0f7453bf9f85eef8887a546ec87db5ddb178945", size = 2051938, upload-time = "2025-10-14T10:19:48.237Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d0/cdf7d126825e36d6e3f1eccf257da8954452934ede275a8f390eac775e89/pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b65077a4693a98b90ec5ad8f203ad65802a1b9b6d4a7e48066925a7e1606706", size = 2250710, upload-time = "2025-10-14T10:19:49.619Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1c/af1e6fd5ea596327308f9c8d1654e1285cc3d8de0d584a3c9d7705bf8a7c/pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62637c769dee16eddb7686bf421be48dfc2fae93832c25e25bc7242e698361ba", size = 2367445, upload-time = "2025-10-14T10:19:51.269Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/81/8cece29a6ef1b3a92f956ea6da6250d5b2d2e7e4d513dd3b4f0c7a83dfea/pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dfe3aa529c8f501babf6e502936b9e8d4698502b2cfab41e17a028d91b1ac7b", size = 2072875, upload-time = "2025-10-14T10:19:52.671Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/a6a579f5fc2cd4d5521284a0ab6a426cc6463a7b3897aeb95b12f1ba607b/pydantic_core-2.41.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca2322da745bf2eeb581fc9ea3bbb31147702163ccbcbf12a3bb630e4bf05e1d", size = 2191329, upload-time = "2025-10-14T10:19:54.214Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/03/505020dc5c54ec75ecba9f41119fd1e48f9e41e4629942494c4a8734ded1/pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e8cd3577c796be7231dcf80badcf2e0835a46665eaafd8ace124d886bab4d700", size = 2151658, upload-time = "2025-10-14T10:19:55.843Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5d/2c0d09fb53aa03bbd2a214d89ebfa6304be7df9ed86ee3dc7770257f41ee/pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1cae8851e174c83633f0833e90636832857297900133705ee158cf79d40f03e6", size = 2316777, upload-time = "2025-10-14T10:19:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4b/c2c9c8f5e1f9c864b57d08539d9d3db160e00491c9f5ee90e1bfd905e644/pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a26d950449aae348afe1ac8be5525a00ae4235309b729ad4d3399623125b43c9", size = 2320705, upload-time = "2025-10-14T10:19:59.016Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c3/a74c1c37f49c0a02c89c7340fafc0ba816b29bd495d1a31ce1bdeacc6085/pydantic_core-2.41.4-cp310-cp310-win32.whl", hash = "sha256:0cf2a1f599efe57fa0051312774280ee0f650e11152325e41dfd3018ef2c1b57", size = 1975464, upload-time = "2025-10-14T10:20:00.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/23/5dd5c1324ba80303368f7569e2e2e1a721c7d9eb16acb7eb7b7f85cb1be2/pydantic_core-2.41.4-cp310-cp310-win_amd64.whl", hash = "sha256:a8c2e340d7e454dc3340d3d2e8f23558ebe78c98aa8f68851b04dcb7bc37abdc", size = 2024497, upload-time = "2025-10-14T10:20:03.018Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d4/912e976a2dd0b49f31c98a060ca90b353f3b73ee3ea2fd0030412f6ac5ec/pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1e5ab4fc177dd41536b3c32b2ea11380dd3d4619a385860621478ac2d25ceb00", size = 2106739, upload-time = "2025-10-14T10:23:06.934Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f0/66ec5a626c81eba326072d6ee2b127f8c139543f1bf609b4842978d37833/pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3d88d0054d3fa11ce936184896bed3c1c5441d6fa483b498fac6a5d0dd6f64a9", size = 1932549, upload-time = "2025-10-14T10:23:09.24Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/af/625626278ca801ea0a658c2dcf290dc9f21bb383098e99e7c6a029fccfc0/pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b2a054a8725f05b4b6503357e0ac1c4e8234ad3b0c2ac130d6ffc66f0e170e2", size = 2135093, upload-time = "2025-10-14T10:23:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f6/2fba049f54e0f4975fef66be654c597a1d005320fa141863699180c7697d/pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0d9db5a161c99375a0c68c058e227bee1d89303300802601d76a3d01f74e258", size = 2187971, upload-time = "2025-10-14T10:23:14.437Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/65ab839a2dfcd3b949202f9d920c34f9de5a537c3646662bdf2f7d999680/pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6273ea2c8ffdac7b7fda2653c49682db815aebf4a89243a6feccf5e36c18c347", size = 2147939, upload-time = "2025-10-14T10:23:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/58/627565d3d182ce6dfda18b8e1c841eede3629d59c9d7cbc1e12a03aeb328/pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:4c973add636efc61de22530b2ef83a65f39b6d6f656df97f678720e20de26caa", size = 2311400, upload-time = "2025-10-14T10:23:19.234Z" },
+    { url = "https://files.pythonhosted.org/packages/24/06/8a84711162ad5a5f19a88cead37cca81b4b1f294f46260ef7334ae4f24d3/pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b69d1973354758007f46cf2d44a4f3d0933f10b6dc9bf15cf1356e037f6f731a", size = 2316840, upload-time = "2025-10-14T10:23:21.738Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8b/b7bb512a4682a2f7fbfae152a755d37351743900226d29bd953aaf870eaa/pydantic_core-2.41.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3619320641fd212aaf5997b6ca505e97540b7e16418f4a241f44cdf108ffb50d", size = 2149135, upload-time = "2025-10-14T10:23:24.379Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/10/fb64987804cde41bcc39d9cd757cd5f2bb5d97b389d81aa70238b14b8a7e/pydantic_extra_types-2.10.6.tar.gz", hash = "sha256:c63d70bf684366e6bbe1f4ee3957952ebe6973d41e7802aea0b770d06b116aeb", size = 141858, upload-time = "2025-10-08T13:47:49.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/04/5c918669096da8d1c9ec7bb716bd72e755526103a61bc5e76a3e4fb23b53/pydantic_extra_types-2.10.6-py3-none-any.whl", hash = "sha256:6106c448316d30abf721b5b9fecc65e983ef2614399a24142d689c7546cc246a", size = 40949, upload-time = "2025-10-08T13:47:48.268Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
+]
+
+[[package]]
+name = "pyensembl"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datacache" },
+    { name = "gtfparse" },
+    { name = "memoized-property" },
+    { name = "nose" },
+    { name = "pylint" },
+    { name = "serializable" },
+    { name = "tinytimer" },
+    { name = "typechecks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/4b/6e9ebe274f3c86ebf92003b7e5b9d50a783dde65d95fc24a41df95e69229/pyensembl-2.2.3.tar.gz", hash = "sha256:96d96c1a6823657f0f581b0c22a314e1a34b80a832dd756f0e5217d51356e96a", size = 58544, upload-time = "2022-12-02T19:02:42.87Z" }
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825, upload-time = "2024-08-01T15:01:08.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344, upload-time = "2024-08-01T15:01:06.481Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomli" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/f8/2feda2bc72654811f2596e856c33c2a98225fba717df2b55c8d6a1f5cdad/pylint-4.0.2.tar.gz", hash = "sha256:9c22dfa52781d3b79ce86ab2463940f874921a3e5707bcfc98dd0c019945014e", size = 1572401, upload-time = "2025-10-20T13:02:34.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/8b/2e814a255436fc6d604a60f1e8b8a186e05082aa3c0cabfd9330192496a2/pylint-4.0.2-py3-none-any.whl", hash = "sha256:9627ccd129893fb8ee8e8010261cb13485daca83e61a6f854a85528ee579502d", size = 536019, upload-time = "2025-10-20T13:02:32.778Z" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/7b/a709c85dc716eb85b69f71a4bb375cf1e72758a7e872103f27551243319c/pymongo-4.15.3.tar.gz", hash = "sha256:7a981271347623b5319932796690c2d301668ac3a1965974ac9f5c3b8a22cea5", size = 2470801, upload-time = "2025-10-07T21:57:50.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/38/7ba7e7b57ccf2b04b63796c097c35b32339b2cb6e4d851d9dbb84426dc99/pymongo-4.15.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:482ca9b775747562ce1589df10c97a0e62a604ce5addf933e5819dd967c5e23c", size = 811331, upload-time = "2025-10-07T21:55:59.15Z" },
+    { url = "https://files.pythonhosted.org/packages/11/36/4bd2aa400a64935b59d68d1c35c168bf61613f1f2bb824757079b2415cda/pymongo-4.15.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7eb497519f42ac89c30919a51f80e68a070cfc2f3b0543cac74833cd45a6b9c", size = 811673, upload-time = "2025-10-07T21:56:00.712Z" },
+    { url = "https://files.pythonhosted.org/packages/37/fb/03c3bd14e6eb5236b360cff8598677c4b7b9557eed3021d9b3f6e82de51d/pymongo-4.15.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4a0a054e9937ec8fdb465835509b176f6b032851c8648f6a5d1b19932d0eacd6", size = 1185479, upload-time = "2025-10-07T21:56:02.297Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/27/b5f21d9a556e31d083bb17d0c026244a604a96f7bdb277fd48dee99415ee/pymongo-4.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49fd6e158cf75771b2685a8a221a40ab96010ae34dd116abd06371dc6c38ab60", size = 1203867, upload-time = "2025-10-07T21:56:03.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/09/ffe1a114d7a39f6746c27a6f5a717b1dc5ea763cb0458a9a679142f623aa/pymongo-4.15.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82a490f1ade4ec6a72068e3676b04c126e3043e69b38ec474a87c6444cf79098", size = 1242537, upload-time = "2025-10-07T21:56:04.973Z" },
+    { url = "https://files.pythonhosted.org/packages/af/60/b7968e855284bb67d366dfb50b6a9df4f69676fbbae51f3e647d2dcb12eb/pymongo-4.15.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:982107c667921e896292f4be09c057e2f1a40c645c9bfc724af5dd5fb8398094", size = 1232832, upload-time = "2025-10-07T21:56:06.287Z" },
+    { url = "https://files.pythonhosted.org/packages/23/47/763945c63690d5c1a54d1d2ace352ba150b9e49a5cfdf44fb237e092e604/pymongo-4.15.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:45aebbd369ca79b7c46eaea5b04d2e4afca4eda117b68965a07a9da05d774e4d", size = 1200177, upload-time = "2025-10-07T21:56:07.671Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/1ace9cf4b88addceb5077e5490238a9e20dc9fef75ae4de146f57f408a06/pymongo-4.15.3-cp310-cp310-win32.whl", hash = "sha256:90ad56bd1d769d2f44af74f0fd0c276512361644a3c636350447994412cbc9a1", size = 798320, upload-time = "2025-10-07T21:56:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b7/86563ec80fc41f644c813a3625d8b5672fd1d2b52da53727eca766dfc162/pymongo-4.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:8bd6dd736f5d07a825caf52c38916d5452edc0fac7aee43ec67aba6f61c2dbb7", size = 808150, upload-time = "2025-10-07T21:56:11.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b3/f136483c3d13224ad0b80ac2b7c8f7adb735a296b5e8c94cfc2415b77d70/pymongo-4.15.3-cp310-cp310-win_arm64.whl", hash = "sha256:300eaf83ad053e51966be1839324341b08eaf880d3dc63ada7942d5912e09c49", size = 800930, upload-time = "2025-10-07T21:56:12.917Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/3d/b6ead84ee437444f96862beb68f9796da8c199793bed08e9397b77579f23/pypdf-6.1.3.tar.gz", hash = "sha256:8d420d1e79dc1743f31a57707cabb6dcd5b17e8b9a302af64b30202c5700ab9d", size = 5076271, upload-time = "2025-10-22T16:13:46.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/ed/494fd0cc1190a7c335e6958eeaee6f373a281869830255c2ed4785dac135/pypdf-6.1.3-py3-none-any.whl", hash = "sha256:eb049195e46f014fc155f566fa20e09d70d4646a9891164ac25fa0cbcfcdbcb5", size = 323863, upload-time = "2025-10-22T16:13:44.174Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pysam"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bc/e0a79d74137643940f5406121039d1272f29f55c5330e7b43484b2259da5/pysam-0.22.1.tar.gz", hash = "sha256:18a0b97be95bd71e584de698441c46651cdff378db1c9a4fb3f541e560253b22", size = 4643640, upload-time = "2024-04-24T02:11:14.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/69/8bb2a2c480f3b50f31da6d2b8a9a8b4439be09def92ead91b2347ba9c962/pysam-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f18e72013ef2db9a9bb7e8ac421934d054427f6c03e66ce8abc39b09c846ba72", size = 6025489, upload-time = "2024-04-24T02:10:32.208Z" },
+    { url = "https://files.pythonhosted.org/packages/23/dc/141cb9377349ad99673764090c483bf2f768768592f0de8fa378a87b8d96/pysam-0.22.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:79cd94eeb96541385fa99e759a8f83d21428e092c8b577d50b4eee5823e757cd", size = 7985505, upload-time = "2024-04-24T01:10:05.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/04/02ff5067fd70220d692809fe5f549e81f3d8a287d140aefcc67ebd6c9294/pysam-0.22.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c71ea45461ee596949061f321a799a97c418164485fdd7e8db89aea2ff979092", size = 21383085, upload-time = "2024-04-24T01:10:08.655Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9f/046a0a1008235f512077ea2edc96bb59365e3a2abd1b5f8de0dbeaf14b1c/pysam-0.22.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ab3343f221994d163e1ba2691430ce0f6e7da13762473e0d7f9a2d5db3bec235", size = 22012406, upload-time = "2024-04-24T02:10:35.527Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-engineio"
+version = "4.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/d8/63e5535ab21dc4998ba1cfe13690ccf122883a38f025dca24d6e56c05eba/python_engineio-4.12.3.tar.gz", hash = "sha256:35633e55ec30915e7fc8f7e34ca8d73ee0c080cec8a8cd04faf2d7396f0a7a7a", size = 91910, upload-time = "2025-09-28T06:31:36.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/f0/c5aa0a69fd9326f013110653543f36ece4913c17921f3e1dbd78e1b423ee/python_engineio-4.12.3-py3-none-any.whl", hash = "sha256:7c099abb2a27ea7ab429c04da86ab2d82698cdd6c52406cb73766fe454feb7e1", size = 59637, upload-time = "2025-09-28T06:31:35.354Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/02f5970c82285bd015ec433078bfc3275580b03715ed6024607dbe0f1966/python_socketio-5.14.3.tar.gz", hash = "sha256:cd8da5e0666e741b4be19e07882e880f57a4751d1645f92c2bc746c95f23b1eb", size = 124266, upload-time = "2025-10-29T09:42:53.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1a/b393a06aa6f2f6ab4a9c5c160a62d488b17d6da5cf93a67bc13a6e3239cd/python_socketio-5.14.3-py3-none-any.whl", hash = "sha256:a5208c1bbf45a8d6328d01ed67e3fa52ec8b186fd3ea44cfcfcbd120f0c71fbe", size = 79010, upload-time = "2025-10-29T09:42:52.098Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+]
+
+[[package]]
+name = "readchar"
+version = "4.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/f8/8657b8cbb4ebeabfbdf991ac40eca8a1d1bd012011bd44ad1ed10f5cb494/readchar-4.2.1.tar.gz", hash = "sha256:91ce3faf07688de14d800592951e5575e9c7a3213738ed01d394dcc949b79adb", size = 9685, upload-time = "2024-11-04T18:28:07.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl", hash = "sha256:a769305cd3994bb5fa2764aa4073452dc105a4ec39068ffe6efd3c20c60acc77", size = 9350, upload-time = "2024-11-04T18:28:02.859Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2025.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/a9/546676f25e573a4cf00fe8e119b78a37b6a8fe2dc95cda877b30889c9c45/regex-2025.11.3.tar.gz", hash = "sha256:1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01", size = 414669, upload-time = "2025-11-03T21:34:22.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/d6/d788d52da01280a30a3f6268aef2aa71043bff359c618fea4c5b536654d5/regex-2025.11.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b441a4ae2c8049106e8b39973bfbddfb25a179dda2bdb99b0eeb60c40a6a3af", size = 488087, upload-time = "2025-11-03T21:30:47.317Z" },
+    { url = "https://files.pythonhosted.org/packages/69/39/abec3bd688ec9bbea3562de0fd764ff802976185f5ff22807bf0a2697992/regex-2025.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2fa2eed3f76677777345d2f81ee89f5de2f5745910e805f7af7386a920fa7313", size = 290544, upload-time = "2025-11-03T21:30:49.912Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b3/9a231475d5653e60002508f41205c61684bb2ffbf2401351ae2186897fc4/regex-2025.11.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8b4a27eebd684319bdf473d39f1d79eed36bf2cd34bd4465cdb4618d82b3d56", size = 288408, upload-time = "2025-11-03T21:30:51.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c5/1929a0491bd5ac2d1539a866768b88965fa8c405f3e16a8cef84313098d6/regex-2025.11.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cf77eac15bd264986c4a2c63353212c095b40f3affb2bc6b4ef80c4776c1a28", size = 781584, upload-time = "2025-11-03T21:30:52.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fd/16aa16cf5d497ef727ec966f74164fbe75d6516d3d58ac9aa989bc9cdaad/regex-2025.11.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f9ee819f94c6abfa56ec7b1dbab586f41ebbdc0a57e6524bd5e7f487a878c7", size = 850733, upload-time = "2025-11-03T21:30:53.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/49/3294b988855a221cb6565189edf5dc43239957427df2d81d4a6b15244f64/regex-2025.11.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:838441333bc90b829406d4a03cb4b8bf7656231b84358628b0406d803931ef32", size = 898691, upload-time = "2025-11-03T21:30:55.575Z" },
+    { url = "https://files.pythonhosted.org/packages/14/62/b56d29e70b03666193369bdbdedfdc23946dbe9f81dd78ce262c74d988ab/regex-2025.11.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfe6d3f0c9e3b7e8c0c694b24d25e677776f5ca26dce46fd6b0489f9c8339391", size = 791662, upload-time = "2025-11-03T21:30:57.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fc/e4c31d061eced63fbf1ce9d853975f912c61a7d406ea14eda2dd355f48e7/regex-2025.11.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2ab815eb8a96379a27c3b6157fcb127c8f59c36f043c1678110cea492868f1d5", size = 782587, upload-time = "2025-11-03T21:30:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/bb/5e30c7394bcf63f0537121c23e796be67b55a8847c3956ae6068f4c70702/regex-2025.11.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:728a9d2d173a65b62bdc380b7932dd8e74ed4295279a8fe1021204ce210803e7", size = 774709, upload-time = "2025-11-03T21:31:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c4/fce773710af81b0cb37cb4ff0947e75d5d17dee304b93d940b87a67fc2f4/regex-2025.11.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:509dc827f89c15c66a0c216331260d777dd6c81e9a4e4f830e662b0bb296c313", size = 845773, upload-time = "2025-11-03T21:31:01.583Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5e/9466a7ec4b8ec282077095c6eb50a12a389d2e036581134d4919e8ca518c/regex-2025.11.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:849202cd789e5f3cf5dcc7822c34b502181b4824a65ff20ce82da5524e45e8e9", size = 836164, upload-time = "2025-11-03T21:31:03.244Z" },
+    { url = "https://files.pythonhosted.org/packages/95/18/82980a60e8ed1594eb3c89eb814fb276ef51b9af7caeab1340bfd8564af6/regex-2025.11.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b6f78f98741dcc89607c16b1e9426ee46ce4bf31ac5e6b0d40e81c89f3481ea5", size = 779832, upload-time = "2025-11-03T21:31:04.876Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/90ab0fdbe6dce064a42015433f9152710139fb04a8b81b4fb57a1cb63ffa/regex-2025.11.3-cp310-cp310-win32.whl", hash = "sha256:149eb0bba95231fb4f6d37c8f760ec9fa6fabf65bab555e128dde5f2475193ec", size = 265802, upload-time = "2025-11-03T21:31:06.581Z" },
+    { url = "https://files.pythonhosted.org/packages/34/9d/e9e8493a85f3b1ddc4a5014465f5c2b78c3ea1cbf238dcfde78956378041/regex-2025.11.3-cp310-cp310-win_amd64.whl", hash = "sha256:ee3a83ce492074c35a74cc76cf8235d49e77b757193a5365ff86e3f2f93db9fd", size = 277722, upload-time = "2025-11-03T21:31:08.144Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c4/b54b24f553966564506dbf873a3e080aef47b356a3b39b5d5aba992b50db/regex-2025.11.3-cp310-cp310-win_arm64.whl", hash = "sha256:38af559ad934a7b35147716655d4a2f79fcef2d695ddfe06a06ba40ae631fa7e", size = 270289, upload-time = "2025-11-03T21:31:10.267Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/dc/95f074d43452b3ef5d06276696ece4b3b5d696e7c9ad7173c54b1390cd70/rpds_py-0.28.0.tar.gz", hash = "sha256:abd4df20485a0983e2ca334a216249b6186d6e3c1627e106651943dbdb791aea", size = 27419, upload-time = "2025-10-22T22:24:29.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/f8/13bb772dc7cbf2c3c5b816febc34fa0cb2c64a08e0569869585684ce6631/rpds_py-0.28.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7b6013db815417eeb56b2d9d7324e64fcd4fa289caeee6e7a78b2e11fc9b438a", size = 362820, upload-time = "2025-10-22T22:21:15.074Z" },
+    { url = "https://files.pythonhosted.org/packages/84/91/6acce964aab32469c3dbe792cb041a752d64739c534e9c493c701ef0c032/rpds_py-0.28.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a4c6b05c685c0c03f80dabaeb73e74218c49deea965ca63f76a752807397207", size = 348499, upload-time = "2025-10-22T22:21:17.658Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/93/c05bb1f4f5e0234db7c4917cb8dd5e2e0a9a7b26dc74b1b7bee3c9cfd477/rpds_py-0.28.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4794c6c3fbe8f9ac87699b131a1f26e7b4abcf6d828da46a3a52648c7930eba", size = 379356, upload-time = "2025-10-22T22:21:19.847Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/37/e292da436f0773e319753c567263427cdf6c645d30b44f09463ff8216cda/rpds_py-0.28.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2e8456b6ee5527112ff2354dd9087b030e3429e43a74f480d4a5ca79d269fd85", size = 390151, upload-time = "2025-10-22T22:21:21.569Z" },
+    { url = "https://files.pythonhosted.org/packages/76/87/a4e3267131616e8faf10486dc00eaedf09bd61c87f01e5ef98e782ee06c9/rpds_py-0.28.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:beb880a9ca0a117415f241f66d56025c02037f7c4efc6fe59b5b8454f1eaa50d", size = 524831, upload-time = "2025-10-22T22:21:23.394Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c8/4a4ca76f0befae9515da3fad11038f0fce44f6bb60b21fe9d9364dd51fb0/rpds_py-0.28.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6897bebb118c44b38c9cb62a178e09f1593c949391b9a1a6fe777ccab5934ee7", size = 404687, upload-time = "2025-10-22T22:21:25.201Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/65/118afe854424456beafbbebc6b34dcf6d72eae3a08b4632bc4220f8240d9/rpds_py-0.28.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b553dd06e875249fd43efd727785efb57a53180e0fde321468222eabbeaafa", size = 382683, upload-time = "2025-10-22T22:21:26.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/bc/0625064041fb3a0c77ecc8878c0e8341b0ae27ad0f00cf8f2b57337a1e63/rpds_py-0.28.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:f0b2044fdddeea5b05df832e50d2a06fe61023acb44d76978e1b060206a8a476", size = 398927, upload-time = "2025-10-22T22:21:27.864Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/1a/fed7cf2f1ee8a5e4778f2054153f2cfcf517748875e2f5b21cf8907cd77d/rpds_py-0.28.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05cf1e74900e8da73fa08cc76c74a03345e5a3e37691d07cfe2092d7d8e27b04", size = 411590, upload-time = "2025-10-22T22:21:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/a8e0f67fa374a6c472dbb0afdaf1ef744724f165abb6899f20e2f1563137/rpds_py-0.28.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:efd489fec7c311dae25e94fe7eeda4b3d06be71c68f2cf2e8ef990ffcd2cd7e8", size = 559843, upload-time = "2025-10-22T22:21:30.917Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ea/e10353f6d7c105be09b8135b72787a65919971ae0330ad97d87e4e199880/rpds_py-0.28.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ada7754a10faacd4f26067e62de52d6af93b6d9542f0df73c57b9771eb3ba9c4", size = 584188, upload-time = "2025-10-22T22:21:32.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/b0/a19743e0763caf0c89f6fc6ba6fbd9a353b24ffb4256a492420c5517da5a/rpds_py-0.28.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c2a34fd26588949e1e7977cfcbb17a9a42c948c100cab890c6d8d823f0586457", size = 550052, upload-time = "2025-10-22T22:21:34.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bc/ec2c004f6c7d6ab1e25dae875cdb1aee087c3ebed5b73712ed3000e3851a/rpds_py-0.28.0-cp310-cp310-win32.whl", hash = "sha256:f9174471d6920cbc5e82a7822de8dfd4dcea86eb828b04fc8c6519a77b0ee51e", size = 215110, upload-time = "2025-10-22T22:21:36.645Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/de/4ce8abf59674e17187023933547d2018363e8fc76ada4f1d4d22871ccb6e/rpds_py-0.28.0-cp310-cp310-win_amd64.whl", hash = "sha256:6e32dd207e2c4f8475257a3540ab8a93eff997abfa0a3fdb287cae0d6cd874b8", size = 223850, upload-time = "2025-10-22T22:21:38.006Z" },
+]
+
+[[package]]
+name = "rpy2"
+version = "3.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "sys_platform == 'win32'" },
+    { name = "rpy2-rinterface" },
+    { name = "rpy2-robjects" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/ba/393d5aaf21204d7678e59f7e7cd54d9a929d5f7ad8218f172100c8c7a6c8/rpy2-3.6.4.tar.gz", hash = "sha256:a24e8dda5c5ff8cbd2b8ebd1ccf6f1a5a0a576623700cf91e2cce98d41a79fd3", size = 53247, upload-time = "2025-09-26T00:31:37.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/93/d49eccd6662ff5cec439f9de716e6520c990cec031fcdd8d08e7fd530681/rpy2-3.6.4-py3-none-any.whl", hash = "sha256:edf437d6637b89311f860fb3e44144ea5eff286a65c48645805833baff090621", size = 9895, upload-time = "2025-09-26T00:31:36.841Z" },
+]
+
+[[package]]
+name = "rpy2-rinterface"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "packaging", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/2a/6ced3b62a9cbfd1f3c24f7005f6eca492d906a4b6a6d56d097a116f14539/rpy2_rinterface-3.6.3.tar.gz", hash = "sha256:477bc2f51d007ad1b8567c5d4ba1af0f59951686ee7f10576a06d0834de5776f", size = 79406, upload-time = "2025-09-04T22:50:50.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/37/693585c2f245cd2f55e13e76474cf91387bcf87aa7aab0fed34ff6a38a98/rpy2_rinterface-3.6.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:164a0bce6ce01569a5c6088e51c1c4f8731929da6ace4a9e196eb68cddde234a", size = 173186, upload-time = "2025-09-04T22:52:31.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ce/98a476a958489d26a1ea77e0191fb05936197295fab7eed20f5b78a92a0c/rpy2_rinterface-3.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:d8c9b03ea5e70b4ee57393dd470646e9219a7a0a3a3c62a5ba030b8a2639e75a", size = 174111, upload-time = "2025-09-04T22:53:29.189Z" },
+]
+
+[[package]]
+name = "rpy2-robjects"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "packaging", marker = "sys_platform == 'win32'" },
+    { name = "rpy2-rinterface" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/58/107252dab2d342eb77bd84d672abc6ecb57428758e251cfccf841c4b6a69/rpy2_robjects-3.6.3.tar.gz", hash = "sha256:731aa1a4905c4b25c0564d72cbfd85f9230102f989e7a22515885e91d4df3d40", size = 105849, upload-time = "2025-09-26T00:31:27.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/af/a794c935ddd3dd8b47a8931e0c8cee1b756ff983db288284786ad29a8bf8/rpy2_robjects-3.6.3-py3-none-any.whl", hash = "sha256:de58c7126dbcd66c4692e7aef91d3cc57a96134828d37a268669f78ee64b974d", size = 125862, upload-time = "2025-09-26T00:31:26.623Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/c7/ee630b29e04a672ecfc9b63227c87fd7a37eb67c1bf30fe95376437f897c/ruamel.yaml-0.18.16.tar.gz", hash = "sha256:a6e587512f3c998b2225d68aa1f35111c29fad14aed561a26e73fab729ec5e5a", size = 147269, upload-time = "2025-10-22T17:54:02.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl", hash = "sha256:048f26d64245bae57a4f9ef6feb5b552a386830ef7a826f235ffb804c59efbba", size = 119858, upload-time = "2025-10-22T17:53:59.012Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e9/39ec4d4b3f91188fad1842748f67d4e749c77c37e353c4e545052ee8e893/ruamel.yaml.clib-0.2.14.tar.gz", hash = "sha256:803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e", size = 225394, upload-time = "2025-09-22T19:51:23.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/56/35a0a752415ae01992c68f5a6513bdef0e1b6fbdb60d7619342ce12346a0/ruamel.yaml.clib-0.2.14-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f8b2acb0ffdd2ce8208accbec2dca4a06937d556fdcaefd6473ba1b5daa7e3c4", size = 269216, upload-time = "2025-09-23T14:24:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6a/9a68184ab93619f4607ff1675e4ef01e8accfcbff0d482f4ca44c10d8eab/ruamel.yaml.clib-0.2.14-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:aef953f3b8bd0b50bd52a2e52fb54a6a2171a1889d8dea4a5959d46c6624c451", size = 137092, upload-time = "2025-09-22T19:50:26.906Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/3f/cfed5f088628128a9ec66f46794fd4d165642155c7b78c26d83b16c6bf7b/ruamel.yaml.clib-0.2.14-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a0ac90efbc7a77b0d796c03c8cc4e62fd710b3f1e4c32947713ef2ef52e09543", size = 633768, upload-time = "2025-09-22T19:50:31.228Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d5/5ce2cc156c1da48160171968d91f066d305840fbf930ee955a509d025a44/ruamel.yaml.clib-0.2.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9bf6b699223afe6c7fe9f2ef76e0bfa6dd892c21e94ce8c957478987ade76cd8", size = 721253, upload-time = "2025-09-22T19:50:28.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/71/d0b56bc902b38ebe4be8e270f730f929eec4edaf8a0fa7028f4ef64fa950/ruamel.yaml.clib-0.2.14-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d73a0187718f6eec5b2f729b0f98e4603f7bd9c48aa65d01227d1a5dcdfbe9e8", size = 683823, upload-time = "2025-09-22T19:50:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/db/1f37449dd89c540218598316ccafc1a0aed60215e72efa315c5367cfd015/ruamel.yaml.clib-0.2.14-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81f6d3b19bc703679a5705c6a16dabdc79823c71d791d73c65949be7f3012c02", size = 690370, upload-time = "2025-09-23T18:42:46.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/53/c498b30f35efcd9f47cb084d7ad9374f2b907470f73913dec6396b81397d/ruamel.yaml.clib-0.2.14-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b28caeaf3e670c08cb7e8de221266df8494c169bd6ed8875493fab45be9607a4", size = 703578, upload-time = "2025-09-22T19:50:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/34/79/492cfad9baed68914840c39e5f3c1cc251f51a897ddb3f532601215cbb12/ruamel.yaml.clib-0.2.14-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94f3efb718f8f49b031f2071ec7a27dd20cbfe511b4dfd54ecee54c956da2b31", size = 722544, upload-time = "2025-09-22T19:50:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/479ebfd5ba396e209ade90f7282d84b90c57b3e07be8dc6fcd02a6df7ffc/ruamel.yaml.clib-0.2.14-cp310-cp310-win32.whl", hash = "sha256:27c070cf3888e90d992be75dd47292ff9aa17dafd36492812a6a304a1aedc182", size = 100375, upload-time = "2025-09-22T19:50:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/a044520fdb3bd409889f67f1efebda0658033c7ab3f390cee37531cc9a9e/ruamel.yaml.clib-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:4f4a150a737fccae13fb51234d41304ff2222e3b7d4c8e9428ed1a6ab48389b8", size = 118129, upload-time = "2025-09-22T19:50:35.545Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/cc/738f3011628920e027a11754d9cae9abec1aed00f7ae860abbf843755233/safetensors-0.6.2.tar.gz", hash = "sha256:43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9", size = 197968, upload-time = "2025-08-08T13:13:58.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b1/3f5fd73c039fc87dba3ff8b5d528bfc5a32b597fea8e7a6a4800343a17c7/safetensors-0.6.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9c85ede8ec58f120bad982ec47746981e210492a6db876882aa021446af8ffba", size = 454797, upload-time = "2025-08-08T13:13:52.066Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c9/bb114c158540ee17907ec470d01980957fdaf87b4aa07914c24eba87b9c6/safetensors-0.6.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6675cf4b39c98dbd7d940598028f3742e0375a6b4d4277e76beb0c35f4b843b", size = 432206, upload-time = "2025-08-08T13:13:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/f70c34e47df3110e8e0bb268d90db8d4be8958a54ab0336c9be4fe86dac8/safetensors-0.6.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d2d2b3ce1e2509c68932ca03ab8f20570920cd9754b05063d4368ee52833ecd", size = 473261, upload-time = "2025-08-08T13:13:41.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/be9c6a7c7ef773e1996dc214e73485286df1836dbd063e8085ee1976f9cb/safetensors-0.6.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:93de35a18f46b0f5a6a1f9e26d91b442094f2df02e9fd7acf224cfec4238821a", size = 485117, upload-time = "2025-08-08T13:13:43.506Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/55/23f2d0a2c96ed8665bf17a30ab4ce5270413f4d74b6d87dd663258b9af31/safetensors-0.6.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89a89b505f335640f9120fac65ddeb83e40f1fd081cb8ed88b505bdccec8d0a1", size = 616154, upload-time = "2025-08-08T13:13:45.096Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/affb0bd9ce02aa46e7acddbe087912a04d953d7a4d74b708c91b5806ef3f/safetensors-0.6.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc4d0d0b937e04bdf2ae6f70cd3ad51328635fe0e6214aa1fc811f3b576b3bda", size = 520713, upload-time = "2025-08-08T13:13:46.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5d/5a514d7b88e310c8b146e2404e0dc161282e78634d9358975fd56dfd14be/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8045db2c872db8f4cbe3faa0495932d89c38c899c603f21e9b6486951a5ecb8f", size = 485835, upload-time = "2025-08-08T13:13:49.373Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7b/4fc3b2ba62c352b2071bea9cfbad330fadda70579f617506ae1a2f129cab/safetensors-0.6.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:81e67e8bab9878bb568cffbc5f5e655adb38d2418351dc0859ccac158f753e19", size = 521503, upload-time = "2025-08-08T13:13:47.651Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/50/0057e11fe1f3cead9254315a6c106a16dd4b1a19cd247f7cc6414f6b7866/safetensors-0.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0e4d029ab0a0e0e4fdf142b194514695b1d7d3735503ba700cf36d0fc7136ce", size = 652256, upload-time = "2025-08-08T13:13:53.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/29/473f789e4ac242593ac1656fbece6e1ecd860bb289e635e963667807afe3/safetensors-0.6.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fa48268185c52bfe8771e46325a1e21d317207bcabcb72e65c6e28e9ffeb29c7", size = 747281, upload-time = "2025-08-08T13:13:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/68/52/f7324aad7f2df99e05525c84d352dc217e0fa637a4f603e9f2eedfbe2c67/safetensors-0.6.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:d83c20c12c2d2f465997c51b7ecb00e407e5f94d7dec3ea0cc11d86f60d3fde5", size = 692286, upload-time = "2025-08-08T13:13:55.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/cad1d9762868c7c5dc70c8620074df28ebb1a8e4c17d4c0cb031889c457e/safetensors-0.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d944cea65fad0ead848b6ec2c37cc0b197194bec228f8020054742190e9312ac", size = 655957, upload-time = "2025-08-08T13:13:57.029Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/e2158e17bbe57d104f0abbd95dff60dda916cf277c9f9663b4bf9bad8b6e/safetensors-0.6.2-cp38-abi3-win32.whl", hash = "sha256:cab75ca7c064d3911411461151cb69380c9225798a20e712b102edda2542ddb1", size = 308926, upload-time = "2025-08-08T13:14:01.095Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c3/c0be1135726618dc1e28d181b8c442403d8dbb9e273fd791de2d4384bcdd/safetensors-0.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:c7b214870df923cbc1593c3faee16bec59ea462758699bd3fee399d00aac072c", size = 320192, upload-time = "2025-08-08T13:13:59.467Z" },
+]
+
+[[package]]
+name = "scikit-allel"
+version = "1.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask", extra = ["array"] },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/ac/724b3f309013aa9025d13f66c1e2c6d30f006c039e90f397ed46e8962bed/scikit_allel-1.3.13.tar.gz", hash = "sha256:9a38b4cc00d3ba9ad997aaa57d0f03f3331e4771e3889f0d9c584a0d7f533e35", size = 9735211, upload-time = "2024-09-17T10:35:32.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7d/3b9292d88ea15e7a11e935cf175d356ecb9790a3437a0f4e6baaab59549b/scikit_allel-1.3.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eb786c909c34b682205c3cacba9b4f0866e658917f30e2f97e1051d9fb2e7ccc", size = 1431567, upload-time = "2024-09-17T10:45:29.2Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fa/d09fd2fb2806d522ae8d66c5834ead98b9c42d01b5ede64bfd9177d7eff9/scikit_allel-1.3.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1853068621208fc2d5537e9a5b292aef2d5e8c975fa35f8f810b3174e0226160", size = 1269298, upload-time = "2024-09-17T10:45:31.267Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ab/8a7e6726076f6e6cb5ee828bc460b006b1468ac4ddd647dde7fd5a66a106/scikit_allel-1.3.13-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f772ff685ca20cc5781765448a7dd0d903be9cee8f3459a22510c530e28e3e5e", size = 8083585, upload-time = "2024-09-17T10:45:33.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/2b/ccc198f489d4d5f3d80ae9a276b22efa6048f1acd74df15db50e810437ee/scikit_allel-1.3.13-cp310-cp310-win_amd64.whl", hash = "sha256:53d580c8a919ee9cda9b9040b92e761ce1757310afdf9aaf65dc55687b1693d6", size = 1217386, upload-time = "2024-09-17T10:45:35.875Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pillow" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/96/f3f3409179d14dbfdbea8622e2e9eaa3c8836ddcaecd2cd5ff0a11731d20/sentence_transformers-5.1.2.tar.gz", hash = "sha256:0f6c8bd916a78dc65b366feb8d22fd885efdb37432e7630020d113233af2b856", size = 375185, upload-time = "2025-10-22T12:47:55.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/a6/a607a737dc1a00b7afe267b9bfde101b8cee2529e197e57471d23137d4e5/sentence_transformers-5.1.2-py3-none-any.whl", hash = "sha256:724ce0ea62200f413f1a5059712aff66495bc4e815a1493f7f9bca242414c333", size = 488009, upload-time = "2025-10-22T12:47:53.433Z" },
+]
+
+[[package]]
+name = "serializable"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simplejson" },
+    { name = "typechecks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/29/98d529dbd22b079ad29a80531cef271894ed2aaf4f3310b8c3b102c95e4e/serializable-0.4.1.tar.gz", hash = "sha256:882098d79253d38591a3d4d7d5d78052fce3ba4d29d64c1704d73f1a19d066d8", size = 12873, upload-time = "2024-04-05T19:58:31.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/a6/736a99c39baa85cf51922526525300fb732f2d31138c28ae1634370bf8bf/serializable-0.4.1-py3-none-any.whl", hash = "sha256:d1f09fade42cc49f9cdf138cd8d2d3515beb1605507ae26983ea812bae77b3e2", size = 12947, upload-time = "2024-04-05T19:58:30.696Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
+name = "simplejson"
+version = "3.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f4/a1ac5ed32f7ed9a088d62a59d410d4c204b3b3815722e2ccfb491fa8251b/simplejson-3.20.2.tar.gz", hash = "sha256:5fe7a6ce14d1c300d80d08695b7f7e633de6cd72c80644021874d985b3393649", size = 85784, upload-time = "2025-09-26T16:29:36.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/09/2bf3761de89ea2d91bdce6cf107dcd858892d0adc22c995684878826cc6b/simplejson-3.20.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6d7286dc11af60a2f76eafb0c2acde2d997e87890e37e24590bb513bec9f1bc5", size = 94039, upload-time = "2025-09-26T16:27:29.283Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/33/c3277db8931f0ae9e54b9292668863365672d90fb0f632f4cf9829cb7d68/simplejson-3.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c01379b4861c3b0aa40cba8d44f2b448f5743999aa68aaa5d3ef7049d4a28a2d", size = 75894, upload-time = "2025-09-26T16:27:30.378Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ea/ae47b04d03c7c8a7b7b1a8b39a6e27c3bd424e52f4988d70aca6293ff5e5/simplejson-3.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a16b029ca25645b3bc44e84a4f941efa51bf93c180b31bd704ce6349d1fc77c1", size = 76116, upload-time = "2025-09-26T16:27:31.42Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/42/6c9af551e5a8d0f171d6dce3d9d1260068927f7b80f1f09834e07887c8c4/simplejson-3.20.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e22a5fb7b1437ffb057e02e1936a3bfb19084ae9d221ec5e9f4cf85f69946b6", size = 138827, upload-time = "2025-09-26T16:27:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/22/5e268bbcbe9f75577491e406ec0a5536f5b2fa91a3b52031fea51cd83e1d/simplejson-3.20.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8b6ff02fc7b8555c906c24735908854819b0d0dc85883d453e23ca4c0445d01", size = 146772, upload-time = "2025-09-26T16:27:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/800f14728e2ad666f420dfdb57697ca128aeae7f991b35759c09356b829a/simplejson-3.20.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bfc1c396ad972ba4431130b42307b2321dba14d988580c1ac421ec6a6b7cee3", size = 134497, upload-time = "2025-09-26T16:27:35.211Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b9/c54eef4226c6ac8e9a389bbe5b21fef116768f97a2dc1a683c716ffe66ef/simplejson-3.20.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a97249ee1aee005d891b5a211faf58092a309f3d9d440bc269043b08f662eda", size = 138172, upload-time = "2025-09-26T16:27:36.44Z" },
+    { url = "https://files.pythonhosted.org/packages/09/36/4e282f5211b34620f1b2e4b51d9ddaab5af82219b9b7b78360a33f7e5387/simplejson-3.20.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f1036be00b5edaddbddbb89c0f80ed229714a941cfd21e51386dc69c237201c2", size = 140272, upload-time = "2025-09-26T16:27:37.605Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/94ad2cf32f477c449e1f63c863d8a513e2408d651c4e58fe4b6a7434e168/simplejson-3.20.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5d6f5bacb8cdee64946b45f2680afa3f54cd38e62471ceda89f777693aeca4e4", size = 140468, upload-time = "2025-09-26T16:27:39.015Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/46/827731e4163be3f987cb8ee90f5d444161db8f540b5e735355faa098d9bc/simplejson-3.20.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8db6841fb796ec5af632f677abf21c6425a1ebea0d9ac3ef1a340b8dc69f52b8", size = 148700, upload-time = "2025-09-26T16:27:40.171Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/28/c32121064b1ec2fb7b5d872d9a1abda62df064d35e0160eddfa907118343/simplejson-3.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c0a341f7cc2aae82ee2b31f8a827fd2e51d09626f8b3accc441a6907c88aedb7", size = 141323, upload-time = "2025-09-26T16:27:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b6/c897c54326fe86dd12d101981171a49361949f4728294f418c3b86a1af77/simplejson-3.20.2-cp310-cp310-win32.whl", hash = "sha256:27f9c01a6bc581d32ab026f515226864576da05ef322d7fc141cd8a15a95ce53", size = 74377, upload-time = "2025-09-26T16:27:42.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/87/a6e03d4d80cca99c1fee4e960f3440e2f21be9470e537970f960ca5547f1/simplejson-3.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:c0a63ec98a4547ff366871bf832a7367ee43d047bcec0b07b66c794e2137b476", size = 76081, upload-time = "2025-09-26T16:27:43.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5b/83e1ff87eb60ca706972f7e02e15c0b33396e7bdbd080069a5d1b53cf0d8/simplejson-3.20.2-py3-none-any.whl", hash = "sha256:3b6bb7fb96efd673eac2e4235200bfffdc2353ad12c54117e1e4e2fc485ac017", size = 57309, upload-time = "2025-09-26T16:29:35.312Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f2/840d7b9496825333f532d2e3976b8eadbf52034178aac53630d09fe6e1ef/sqlalchemy-2.0.44.tar.gz", hash = "sha256:0ae7454e1ab1d780aee69fd2aae7d6b8670a581d8847f2d1e0f7ddfbf47e5a22", size = 9819830, upload-time = "2025-10-10T14:39:12.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/a7/e9ccfa7eecaf34c6f57d8cb0bb7cbdeeff27017cc0f5d0ca90fdde7a7c0d/sqlalchemy-2.0.44-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c77f3080674fc529b1bd99489378c7f63fcb4ba7f8322b79732e0258f0ea3ce", size = 2137282, upload-time = "2025-10-10T15:36:10.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/50bc121885bdf10833a4f65ecbe9fe229a3215f4d65a58da8a181734cae3/sqlalchemy-2.0.44-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c26ef74ba842d61635b0152763d057c8d48215d5be9bb8b7604116a059e9985", size = 2127322, upload-time = "2025-10-10T15:36:12.428Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/a8573b7230a3ce5ee4b961a2d510d71b43872513647398e595b744344664/sqlalchemy-2.0.44-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4a172b31785e2f00780eccab00bc240ccdbfdb8345f1e6063175b3ff12ad1b0", size = 3214772, upload-time = "2025-10-10T15:34:15.09Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/c63d8adb6a7edaf8dcb6f75a2b1e9f8577960a1e489606859c4d73e7d32b/sqlalchemy-2.0.44-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9480c0740aabd8cb29c329b422fb65358049840b34aba0adf63162371d2a96e", size = 3214434, upload-time = "2025-10-10T15:47:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a6/243d277a4b54fae74d4797957a7320a5c210c293487f931cbe036debb697/sqlalchemy-2.0.44-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:17835885016b9e4d0135720160db3095dc78c583e7b902b6be799fb21035e749", size = 3155365, upload-time = "2025-10-10T15:34:17.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f8/6a39516ddd75429fd4ee5a0d72e4c80639fab329b2467c75f363c2ed9751/sqlalchemy-2.0.44-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cbe4f85f50c656d753890f39468fcd8190c5f08282caf19219f684225bfd5fd2", size = 3178910, upload-time = "2025-10-10T15:47:02.346Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/118355d4ad3c39d9a2f5ee4c7304a9665b3571482777357fa9920cd7a6b4/sqlalchemy-2.0.44-cp310-cp310-win32.whl", hash = "sha256:2fcc4901a86ed81dc76703f3b93ff881e08761c63263c46991081fd7f034b165", size = 2105624, upload-time = "2025-10-10T15:38:15.552Z" },
+    { url = "https://files.pythonhosted.org/packages/61/83/6ae5f9466f8aa5d0dcebfff8c9c33b98b27ce23292df3b990454b3d434fd/sqlalchemy-2.0.44-cp310-cp310-win_amd64.whl", hash = "sha256:9919e77403a483ab81e3423151e8ffc9dd992c20d2603bf17e4a8161111e55f5", size = 2129240, upload-time = "2025-10-10T15:38:17.175Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/5e/6a29fa884d9fb7ddadf6b69490a9d45fded3b38541713010dad16b77d015/sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05", size = 1928718, upload-time = "2025-10-10T15:29:45.32Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.49.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
+]
+
+[[package]]
+name = "striprtf"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/20/3d419008265346452d09e5dadfd5d045b64b40d8fc31af40588e6c76997a/striprtf-0.0.26.tar.gz", hash = "sha256:fdb2bba7ac440072d1c41eab50d8d74ae88f60a8b6575c6e2c7805dc462093aa", size = 6258, upload-time = "2023-07-20T14:30:36.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/cf/0fea4f4ba3fc2772ac2419278aa9f6964124d4302117d61bc055758e000c/striprtf-0.0.26-py3-none-any.whl", hash = "sha256:8c8f9d32083cdc2e8bfb149455aa1cc5a4e0a035893bedc75db8b73becb3a1bb", size = 6914, upload-time = "2023-07-20T14:30:35.338Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/b3/2cb7c17b6c4cf8ca983204255d3f1d95eda7213e247e6947a0ee2c747a2c/tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970", size = 1051991, upload-time = "2025-10-06T20:21:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0f/df139f1df5f6167194ee5ab24634582ba9a1b62c6b996472b0277ec80f66/tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16", size = 995798, upload-time = "2025-10-06T20:21:35.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5d/26a691f28ab220d5edc09b9b787399b130f24327ef824de15e5d85ef21aa/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cde24cdb1b8a08368f709124f15b36ab5524aac5fa830cc3fdce9c03d4fb8030", size = 1129865, upload-time = "2025-10-06T20:21:36.675Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/94/443fab3d4e5ebecac895712abd3849b8da93b7b7dec61c7db5c9c7ebe40c/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6de0da39f605992649b9cfa6f84071e3f9ef2cec458d08c5feb1b6f0ff62e134", size = 1152856, upload-time = "2025-10-06T20:21:37.873Z" },
+    { url = "https://files.pythonhosted.org/packages/54/35/388f941251b2521c70dd4c5958e598ea6d2c88e28445d2fb8189eecc1dfc/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6faa0534e0eefbcafaccb75927a4a380463a2eaa7e26000f0173b920e98b720a", size = 1195308, upload-time = "2025-10-06T20:21:39.577Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/00/c6681c7f833dd410576183715a530437a9873fa910265817081f65f9105f/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82991e04fc860afb933efb63957affc7ad54f83e2216fe7d319007dab1ba5892", size = 1255697, upload-time = "2025-10-06T20:21:41.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d2/82e795a6a9bafa034bf26a58e68fe9a89eeaaa610d51dbeb22106ba04f0a/tiktoken-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:6fb2995b487c2e31acf0a9e17647e3b242235a20832642bb7a9d1a181c0c1bb1", size = 879375, upload-time = "2025-10-06T20:21:43.201Z" },
+]
+
+[[package]]
+name = "tinytimer"
+version = "0.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/87/75d3fbe15aabd45d9b70702241787cf1f7f30dd9fabcd9bc89d828c7661d/tinytimer-0.0.0.tar.gz", hash = "sha256:6ad13c8f01ab6094e58081a5367ffc4c5831f2d6b29034d2434d8ae106308fa5", size = 2069, upload-time = "2015-03-20T20:00:55.612Z" }
+
+[[package]]
+name = "tokenizers"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/46/fb6854cec3278fbfa4a75b50232c77622bc517ac886156e6afbfa4d8fc6e/tokenizers-0.22.1.tar.gz", hash = "sha256:61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9", size = 363123, upload-time = "2025-09-19T09:49:23.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/33/f4b2d94ada7ab297328fc671fed209368ddb82f965ec2224eb1892674c3a/tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73", size = 3069318, upload-time = "2025-09-19T09:49:11.848Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/58/2aa8c874d02b974990e89ff95826a4852a8b2a273c7d1b4411cdd45a4565/tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc", size = 2926478, upload-time = "2025-09-19T09:49:09.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3b/55e64befa1e7bfea963cf4b787b2cea1011362c4193f5477047532ce127e/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d2962dd28bc67c1f205ab180578a78eef89ac60ca7ef7cbe9635a46a56422a", size = 3256994, upload-time = "2025-09-19T09:48:56.701Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0b/fbfecf42f67d9b7b80fde4aabb2b3110a97fac6585c9470b5bff103a80cb/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38201f15cdb1f8a6843e6563e6e79f4abd053394992b9bbdf5213ea3469b4ae7", size = 3153141, upload-time = "2025-09-19T09:48:59.749Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a9/b38f4e74e0817af8f8ef925507c63c6ae8171e3c4cb2d5d4624bf58fca69/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1cbe5454c9a15df1b3443c726063d930c16f047a3cc724b9e6e1a91140e5a21", size = 3508049, upload-time = "2025-09-19T09:49:05.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/48/dd2b3dac46bb9134a88e35d72e1aa4869579eacc1a27238f1577270773ff/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7d094ae6312d69cc2a872b54b91b309f4f6fbce871ef28eb27b52a98e4d0214", size = 3710730, upload-time = "2025-09-19T09:49:01.832Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0e/ccabc8d16ae4ba84a55d41345207c1e2ea88784651a5a487547d80851398/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afd7594a56656ace95cdd6df4cca2e4059d294c5cfb1679c57824b605556cb2f", size = 3412560, upload-time = "2025-09-19T09:49:03.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/dc3a0db5a6766416c32c034286d7c2d406da1f498e4de04ab1b8959edd00/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ef6063d7a84994129732b47e7915e8710f27f99f3a3260b8a38fc7ccd083f4", size = 3250221, upload-time = "2025-09-19T09:49:07.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a6/2c8486eef79671601ff57b093889a345dd3d576713ef047776015dc66de7/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ba0a64f450b9ef412c98f6bcd2a50c6df6e2443b560024a09fa6a03189726879", size = 9345569, upload-time = "2025-09-19T09:49:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/32ce667f14c35537f5f605fe9bea3e415ea1b0a646389d2295ec348d5657/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:331d6d149fa9c7d632cde4490fb8bbb12337fa3a0232e77892be656464f4b446", size = 9271599, upload-time = "2025-09-19T09:49:16.639Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7c/a5f7898a3f6baa3fc2685c705e04c98c1094c523051c805cdd9306b8f87e/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:607989f2ea68a46cb1dfbaf3e3aabdf3f21d8748312dbeb6263d1b3b66c5010a", size = 9533862, upload-time = "2025-09-19T09:49:19.146Z" },
+    { url = "https://files.pythonhosted.org/packages/36/65/7e75caea90bc73c1dd8d40438adf1a7bc26af3b8d0a6705ea190462506e1/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a0f307d490295717726598ef6fa4f24af9d484809223bbc253b201c740a06390", size = 9681250, upload-time = "2025-09-19T09:49:21.501Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2c/959dddef581b46e6209da82df3b78471e96260e2bc463f89d23b1bf0e52a/tokenizers-0.22.1-cp39-abi3-win32.whl", hash = "sha256:b5120eed1442765cd90b903bb6cfef781fd8fe64e34ccaecbae4c619b7b12a82", size = 2472003, upload-time = "2025-09-19T09:49:27.089Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/e33a8c93907b631a99377ef4c5f817ab453d0b34f93529421f42ff559671/tokenizers-0.22.1-cp39-abi3-win_amd64.whl", hash = "sha256:65fd6e3fb11ca1e78a6a93602490f134d1fdeb13bcef99389d5102ea318ed138", size = 2674684, upload-time = "2025-09-19T09:49:24.953Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/86/245c240d2138c17ed572c943c289056c2721abab70810d772c6bf5495b28/torch-2.9.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:030bbfe367379ae6a4ae4042b6c44da25383343b8b3c68abaa9c7231efbaf2dd", size = 104213554, upload-time = "2025-10-15T15:45:59.798Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1d/fd1e88ae0948825efcab7dd66d12bec23f05d4d38ed81573c8d453c14c06/torch-2.9.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:51cb63902182a78e90886e8068befd8ea102af4b00e420263591a3d70c7d3c6c", size = 899795167, upload-time = "2025-10-15T15:47:12.695Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/496197b45c14982bef4e079b24c61dc108e3ab0d0cc9718dba9f54f45a46/torch-2.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:3f6aad4d2f0ee2248bac25339d74858ff846c3969b27d14ac235821f055af83d", size = 109310314, upload-time = "2025-10-15T15:46:16.633Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b0/2b4e647b0fc706e88eb6c253d05511865578f5f67b55fad639bf3272a4a1/torch-2.9.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:413e1654c9203733138858780e184d9fc59442f0b3b209e16f39354eb893db9b", size = 74452019, upload-time = "2025-10-15T15:46:04.296Z" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/aa/7fce684dc0e21f8ea3ecf4a9f37253f8fa0b51aa0973202b58f33b9dc031/torchaudio-2.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:214d2e8bec2b204ac3f552f3dceae51550e06a91c5863d5dc341d81691ef655e", size = 806922, upload-time = "2025-10-15T15:51:53.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/212181b1df762487462b3a092f6a9ae6ba87df02df71bb2121c100b13b8d/torchaudio-2.9.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1e84e45f74bf5b208b5ce59b36f26ec1e5f63596542c3ebee6edeadf85e73563", size = 473802, upload-time = "2025-10-15T15:51:55.626Z" },
+    { url = "https://files.pythonhosted.org/packages/39/27/75184741da9aa1e94ec136319781e1275a560d1c311a293cc22aba747863/torchaudio-2.9.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:905f2c916e392b6dde375c002abe98f6fc64705fdf1192c90a6df2de235305f3", size = 2055464, upload-time = "2025-10-15T15:51:57.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/af/f12349d7cb325b9b36452192953eb8c4ca9a6c28c8335c2d2f5e576be7f3/torchaudio-2.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:4ed556da9de16f69ccbe804df510ae8fefdf995cbdc2fcf26ea7532d25463326", size = 663878, upload-time = "2025-10-15T15:52:07.274Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/5b/1404eeab00819df71a30e916c2081654366741f7838fcc4fff86b7bd9e7e/torchvision-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5e8d5e667deff87bd66d26df6d225f46224bb0782d4f3f8f5d2f3068b5fd4492", size = 1891723, upload-time = "2025-10-15T15:51:08.5Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e3/1b003ecd52bd721f8304aeb66691edfbc2002747ec83d36188ad6abab506/torchvision-0.24.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a110a51c75e89807a8382b0d8034f5e180fb9319570be3389ffd3d4ac4fd57a9", size = 2418988, upload-time = "2025-10-15T15:51:25.195Z" },
+    { url = "https://files.pythonhosted.org/packages/56/2e/3c19a35e62da0f606baf8f6e2ceeab1eb66aaa2f84c6528538b06b416d54/torchvision-0.24.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:81d5b12a6df1bb2cc8bdbad837b637d6ea446f2866e6d94f1b5d478856331be3", size = 8046769, upload-time = "2025-10-15T15:51:15.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1d/e7ab614a1ace820a2366eab1532679fbe81bd9501ffd6a1b7be14936366d/torchvision-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:0839dbb305d34671f5a64f558782095134b04bbeff8b90f11eb80515d7d50092", size = 3686529, upload-time = "2025-10-15T15:51:20.982Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.57.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/68/a39307bcc4116a30b2106f2e689130a48de8bd8a1e635b5e1030e46fcd9e/transformers-4.57.1.tar.gz", hash = "sha256:f06c837959196c75039809636cd964b959f6604b75b8eeec6fdfc0440b89cc55", size = 10142511, upload-time = "2025-10-14T15:39:26.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d3/c16c3b3cf7655a67db1144da94b021c200ac1303f82428f2beef6c2e72bb/transformers-4.57.1-py3-none-any.whl", hash = "sha256:b10d05da8fa67dc41644dbbf9bc45a44cb86ae33da6f9295f5fbf5b7890bd267", size = 11990925, upload-time = "2025-10-14T15:39:23.085Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/eb/09e31d107a5d00eb281aa7e6635ca463e9bca86515944e399480eadb71f8/triton-3.5.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5d3b3d480debf24eaa739623c9a42446b0b77f95593d30eb1f64cd2278cc1f0", size = 170333110, upload-time = "2025-10-13T16:37:49.588Z" },
+]
+
+[[package]]
+name = "typechecks"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/21/15129201c1f52f6af1e7809e96dce46da4b406c2c07fe9425e92f51edc5c/typechecks-0.1.0.tar.gz", hash = "sha256:7d801a6018f60d2a10aa3debc3af65f590c96c455de67159f39b9b183107c83b", size = 3397, upload-time = "2018-02-23T19:02:45.854Z" }
+
+[[package]]
+name = "typer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.9.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/f6/9914f57d152cfcb85f3a26f8fbac3c88e4eb9cbe88639076241e16819334/uv-0.9.7.tar.gz", hash = "sha256:555ee72146b8782c73d755e4a21c9885c6bfc81db0ffca2220d52dddae007eb7", size = 3705596, upload-time = "2025-10-30T22:17:18.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/38/cee64a9dcefd46f83a922c4e31d9cd9d91ce0d27a594192f7df677151eb4/uv-0.9.7-py3-none-linux_armv6l.whl", hash = "sha256:134e0daac56f9e399ccdfc9e4635bc0a13c234cad9224994c67bae462e07399a", size = 20614967, upload-time = "2025-10-30T22:16:31.274Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b7/1b1ff8dfde05e9d27abf29ebf22da48428fe1e16f0b4d65a839bd2211303/uv-0.9.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1aaf79b4234400e9e2fbf5b50b091726ccbb0b6d4d032edd3dfd4c9673d89dca", size = 19692886, upload-time = "2025-10-30T22:16:35.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7d/b618174d8a8216af350398ace03805b2b2df6267b1745abf45556c2fda58/uv-0.9.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0fdbfad5b367e7a3968264af6da5bbfffd4944a90319042f166e8df1a2d9de09", size = 18345022, upload-time = "2025-10-30T22:16:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4c/03fafb7d28289d54ac7a34507f1e97e527971f8b0ee2c5e957045966a1a6/uv-0.9.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:635e82c2d0d8b001618af82e4f2724350f15814f6462a71b3ebd44adec21f03c", size = 20170427, upload-time = "2025-10-30T22:16:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f1316da150453755bb88cf4232e8934de71a0091eb274a8b69d948535453/uv-0.9.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a440ccde7624a7bc070e1c2492b358c67aea9b8f17bc243ea27c5871c8d02c", size = 20234277, upload-time = "2025-10-30T22:16:43.521Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b8/cb62cd78151b235c5da9290f0e3fb032b36706f2922208a691678aa0f2df/uv-0.9.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5f1fb8203a77853db176000e8f30d5815ab175dc46199db059f97a72fc51110", size = 21180078, upload-time = "2025-10-30T22:16:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e5/6107249d23f06fa1739496e89699e76169037b4643144b28b324efc3075d/uv-0.9.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bb8bfcc2897f7653522abc2cae80233af756ad857bfbbbbe176f79460cbba417", size = 22743896, upload-time = "2025-10-30T22:16:48.487Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/69d8e0bb29c140305e7677bc8c98c765468a55cb10966e77bb8c69bf815d/uv-0.9.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89697fa0d7384ba047daf75df844ee7800235105e41d08e0c876861a2b4aa90e", size = 22361126, upload-time = "2025-10-30T22:16:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0d/d186456cd0d7972ed026e5977b8a12e1f94c923fc3d6e86c7826c6f0d1fe/uv-0.9.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c9810ee8173dce129c49b338d5e97f3d7c7e9435f73e0b9b26c2f37743d3bb9e", size = 21477489, upload-time = "2025-10-30T22:16:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/59/61d8e9f1734069049abe9e593961de602397c7194712346906c075fec65f/uv-0.9.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cf6bc2482d1293cc630f66b862b494c09acda9b7faff7307ef52667a2b3ad49", size = 21382006, upload-time = "2025-10-30T22:16:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ac/090dbde63abb56001190392d29ca2aa654eebc146a693b5dda68da0df2fb/uv-0.9.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7019f4416925f4091b9d28c1cf3e8444cf910c4ede76bdf1f6b9a56ca5f97985", size = 20255103, upload-time = "2025-10-30T22:16:58.434Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e7/ca2d99a4ce86366731547a84b5a2c946528b8d6d28c74ac659c925955a0c/uv-0.9.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:edd768f6730bba06aa10fdbd80ee064569f7236806f636bf65b68136a430aad0", size = 21311768, upload-time = "2025-10-30T22:17:01.259Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1a/c5d9e57f52aa30bfee703e6b9e5b5072102cfc706f3444377bb0de79eac7/uv-0.9.7-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:d6e5fe28ca05a4b576c0e8da5f69251dc187a67054829cfc4afb2bfa1767114b", size = 20239129, upload-time = "2025-10-30T22:17:03.815Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ab/16110ca6b1c4aaad79b4f2c6bc102c416a906e5d29947d0dc774f6ef4365/uv-0.9.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:34fe0af83fcafb9e2b786f4bd633a06c878d548a7c479594ffb5607db8778471", size = 20647326, upload-time = "2025-10-30T22:17:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/2a8129c796831279cc0c53ffdd19dd6133d514805e52b1ef8a2aa0ff8912/uv-0.9.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:777bb1de174319245a35e4f805d3b4484d006ebedae71d3546f95e7c28a5f436", size = 21604958, upload-time = "2025-10-30T22:17:09.046Z" },
+    { url = "https://files.pythonhosted.org/packages/73/97/616650cb4dd5fbaabf8237469e1bc84710ae878095d359999982e1bc8ecf/uv-0.9.7-py3-none-win32.whl", hash = "sha256:bcf878528bd079fe8ae15928b5dfa232fac8b0e1854a2102da6ae1a833c31276", size = 19418913, upload-time = "2025-10-30T22:17:11.384Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7f/e3cdaffac70852f5ff933b04c7b8a06c0f91f41e563f04b689caa65b71bd/uv-0.9.7-py3-none-win_amd64.whl", hash = "sha256:62b315f62669899076a1953fba6baf50bd2b57f66f656280491331dcedd7e6c6", size = 21443513, upload-time = "2025-10-30T22:17:13.785Z" },
+    { url = "https://files.pythonhosted.org/packages/89/79/8278452acae2fe96829485d32e1a2363829c9e42674704562ffcfc06b140/uv-0.9.7-py3-none-win_arm64.whl", hash = "sha256:d13da6521d4e841b1e0a9fda82e793dcf8458a323a9e8955f50903479d0bfa97", size = 19946729, upload-time = "2025-10-30T22:17:16.669Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/43/a2204825342f37c337f5edb6637040fa14e365b2fcc2346960201d457579/yarl-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7bd6683587567e5a49ee6e336e0612bec8329be1b7d4c8af5687dcdeb67ee1e", size = 140517, upload-time = "2025-10-06T14:08:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6f/674f3e6f02266428c56f704cd2501c22f78e8b2eeb23f153117cc86fb28a/yarl-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cdac20da754f3a723cceea5b3448e1a2074866406adeb4ef35b469d089adb8f", size = 93495, upload-time = "2025-10-06T14:08:46.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/12/5b274d8a0f30c07b91b2f02cba69152600b47830fcfb465c108880fcee9c/yarl-1.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07a524d84df0c10f41e3ee918846e1974aba4ec017f990dc735aad487a0bdfdf", size = 94400, upload-time = "2025-10-06T14:08:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7f/df1b6949b1fa1aa9ff6de6e2631876ad4b73c4437822026e85d8acb56bb1/yarl-1.22.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1b329cb8146d7b736677a2440e422eadd775d1806a81db2d4cded80a48efc1a", size = 347545, upload-time = "2025-10-06T14:08:49.683Z" },
+    { url = "https://files.pythonhosted.org/packages/84/09/f92ed93bd6cd77872ab6c3462df45ca45cd058d8f1d0c9b4f54c1704429f/yarl-1.22.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:75976c6945d85dbb9ee6308cd7ff7b1fb9409380c82d6119bd778d8fcfe2931c", size = 319598, upload-time = "2025-10-06T14:08:51.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/97/ac3f3feae7d522cf7ccec3d340bb0b2b61c56cb9767923df62a135092c6b/yarl-1.22.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:80ddf7a5f8c86cb3eb4bc9028b07bbbf1f08a96c5c0bc1244be5e8fefcb94147", size = 363893, upload-time = "2025-10-06T14:08:53.144Z" },
+    { url = "https://files.pythonhosted.org/packages/06/49/f3219097403b9c84a4d079b1d7bda62dd9b86d0d6e4428c02d46ab2c77fc/yarl-1.22.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d332fc2e3c94dad927f2112395772a4e4fedbcf8f80efc21ed7cdfae4d574fdb", size = 371240, upload-time = "2025-10-06T14:08:55.036Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9f/06b765d45c0e44e8ecf0fe15c9eacbbde342bb5b7561c46944f107bfb6c3/yarl-1.22.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cf71bf877efeac18b38d3930594c0948c82b64547c1cf420ba48722fe5509f6", size = 346965, upload-time = "2025-10-06T14:08:56.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/69/599e7cea8d0fcb1694323b0db0dda317fa3162f7b90166faddecf532166f/yarl-1.22.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:663e1cadaddae26be034a6ab6072449a8426ddb03d500f43daf952b74553bba0", size = 342026, upload-time = "2025-10-06T14:08:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6f/9dfd12c8bc90fea9eab39832ee32ea48f8e53d1256252a77b710c065c89f/yarl-1.22.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:6dcbb0829c671f305be48a7227918cfcd11276c2d637a8033a99a02b67bf9eda", size = 335637, upload-time = "2025-10-06T14:09:00.506Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2e/34c5b4eb9b07e16e873db5b182c71e5f06f9b5af388cdaa97736d79dd9a6/yarl-1.22.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f0d97c18dfd9a9af4490631905a3f131a8e4c9e80a39353919e2cfed8f00aedc", size = 359082, upload-time = "2025-10-06T14:09:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/31/71/fa7e10fb772d273aa1f096ecb8ab8594117822f683bab7d2c5a89914c92a/yarl-1.22.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:437840083abe022c978470b942ff832c3940b2ad3734d424b7eaffcd07f76737", size = 357811, upload-time = "2025-10-06T14:09:03.445Z" },
+    { url = "https://files.pythonhosted.org/packages/26/da/11374c04e8e1184a6a03cf9c8f5688d3e5cec83ed6f31ad3481b3207f709/yarl-1.22.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a899cbd98dce6f5d8de1aad31cb712ec0a530abc0a86bd6edaa47c1090138467", size = 351223, upload-time = "2025-10-06T14:09:05.401Z" },
+    { url = "https://files.pythonhosted.org/packages/82/8f/e2d01f161b0c034a30410e375e191a5d27608c1f8693bab1a08b089ca096/yarl-1.22.0-cp310-cp310-win32.whl", hash = "sha256:595697f68bd1f0c1c159fcb97b661fc9c3f5db46498043555d04805430e79bea", size = 82118, upload-time = "2025-10-06T14:09:11.148Z" },
+    { url = "https://files.pythonhosted.org/packages/62/46/94c76196642dbeae634c7a61ba3da88cd77bed875bf6e4a8bed037505aa6/yarl-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:cb95a9b1adaa48e41815a55ae740cfda005758104049a640a398120bf02515ca", size = 86852, upload-time = "2025-10-06T14:09:12.958Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/7df4f179d3b1a6dcb9a4bd2ffbc67642746fcafdb62580e66876ce83fff4/yarl-1.22.0-cp310-cp310-win_arm64.whl", hash = "sha256:b85b982afde6df99ecc996990d4ad7ccbdbb70e2a4ba4de0aecde5922ba98a0b", size = 82012, upload-time = "2025-10-06T14:09:14.664Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]


### PR DESCRIPTION
Builds on PR #47 by extending the validated Alzheimer's disease LDSC pipeline to the full human chromatin accessibility atlas, updating reference datasets to match the original paper's methodology, and integrating a fully automated harmonization workflow.
Major Changes

- Extended annotation pipeline to incorporate cCRE BED annotations from the CATLAS resource covering 222 cell types across 30 adult and 15 fetal tissue types, replacing the single-source brain-specific approach from PR #47 with a multi-source annotation system with dynamic cell-type discovery and automatic fallback to peak-matrix-derived BEDs for cell types not covered by CATLAS
- Added merged cCREs as a background annotation alongside the baseline in LDSC, consistent with the paper's original methodology
- Replaced GWAS summary statistics with datasets from the paper's OSF repository and updated baseline annotations from v2.2 to v1.2 with matching regression weights
- Integrated gwas-sumstats-harmoniser Nextflow workflow for automated allele harmonization and liftover
- Added dynamic GWAS reformatter with auto-detection of column names and bim-based chr/pos lookup for rs-ID-only files
- Added dynamic N extraction from YAML metadata and auto-detection of pre-formatted LDSC sumstats files skipping harmonization when not needed
- Parallelized LD score computation across the full atlas cell-type set with a pre-regression completeness check to prevent silent failures at regression time

Results
Tested with multiple GWAS datasets including atrial fibrillation (Nielsen et al. 2018), MDD (Howard et al. 2019), and CAD. Results for atrial fibrillation correctly identified cardiomyocytes as the top enriched cell types (Atrial_Cardiomyocyte p = 2.46×10⁻¹³, Ventricular_Cardiomyocyte p = 6.99×10⁻¹², Fetal_Atrial_Cardiomyocyte p = 7.08×10⁻¹²), consistent with the Zhang et al. 2021 paper.