### PR TITLE
cd-update: migrate staging deployment to Kubernetes

### DIFF
--- a/.github/workflows/cd-staging-deployment.yml
+++ b/.github/workflows/cd-staging-deployment.yml
@@ -1,4 +1,4 @@
-name: CD - pull Docker image & build with ansible (staging only)
+name: CD - Deploy to Kubernetes (staging)
 
 on:
   repository_dispatch:
@@ -13,122 +13,102 @@ jobs:
           echo "Event Type: ${{ github.event.action }}"
           echo "Image Tag: ${{ github.event.client_payload.image_tag }}"
           echo "Triggered by: ${{ github.actor }}"
-          echo "Current user: $(whoami)"
-          echo "Home directory: $HOME"
-          echo "Working directory: $(pwd)"
-          echo "User ID: $(id -u)"
-          echo "Group ID: $(id -g)"
 
       - name: Checkout current repository
         uses: actions/checkout@v4
-          
-      - name: Checkout Ansible repository
-        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_STAGING }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
+
+      - name: Deploy to Kubernetes
+        run: |
+          set -euo pipefail
+
+          NAMESPACE="hypothesis-staging"
+          TAG="${{ github.event.client_payload.image_tag }}"
+
+          if [ -z "$TAG" ]; then
+            TAG="staging"
+          fi
+
+          echo "Using image tag: $TAG"
+
+          kubectl set image deployment/hypothesis-api \
+            api=abdum1964/hypothesis-generation-api-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prolog-service \
+            prolog=abdum1964/hypothesis-generation-prolog-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prefect-service \
+            prefect-service=abdum1964/hypothesis-generation-prefect-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prefect-deployment \
+            prefect-deployment=abdum1964/hypothesis-generation-prefect-deployment:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/dask-scheduler \
+            dask-scheduler=abdum1964/hypothesis-generation-dask-scheduler:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/dask-worker \
+            dask-worker=abdum1964/hypothesis-generation-dask-worker:${TAG} \
+            -n "$NAMESPACE"
+
+      - name: Wait for rollout
+        run: |
+          set -euo pipefail
+          kubectl rollout status deployment/hypothesis-api -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prolog-service -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prefect-service -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prefect-deployment -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/dask-scheduler -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/dask-worker -n hypothesis-staging --timeout=180s
+
+      - name: Verify all pods
+        run: |
+          kubectl get pods -n hypothesis-staging
+
+      - name: Send success email
+        if: success()
+        uses: dawidd6/action-send-mail@v3
         with:
-          repository: rejuve-bio/ansible-deploy
-          path: ansible-deploy
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline SUCCESS - Hypothesis Generation Deployed to K8s"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            Deployment to Kubernetes completed successfully!
 
-      - name: Create .env file for Hypothesis_generation
-        run: |
-          mkdir -p $HOME/services/hypothesis-generation-demo
-          cat > $HOME/services/hypothesis-generation-demo/.env << EOF
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
 
-              # === API Keys and Tokens ===
-              ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-              OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-              HF_TOKEN=${{ secrets.HF_TOKEN }}
+            All pods updated and running in staging namespace.
 
-              # === Authentication and Security ===
-              JWT_SECRET=${{ secrets.JWT_SECRET }}
-              JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+      - name: Send failure email
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline FAILED - Hypothesis Generation K8s Deploy"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            Kubernetes deployment failed!
 
-              # === Database Configuration ===
-              DB_NAME=${{ secrets.DB_NAME }}
-              MONGODB_URI=${{ secrets.MONGODB_URI }}
-              MONGO_PORT_HOST=${{ secrets.MONGO_PORT_HOST }}
-              MONGO_PORT_INTERNAL=${{ secrets.MONGO_PORT_INTERNAL }}
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
 
-              # === Prefect Workflow Configuration ===
-              PREFECT_PORT_HOST=${{ secrets.PREFECT_PORT_HOST }}
-              PREFECT_PORT_INTERNAL=${{ secrets.PREFECT_PORT_INTERNAL }}
-
-              # === Prolog Microservice Configuration ===
-              PROLOG_PORT_HOST=${{ secrets.PROLOG_PORT_HOST }}
-              PROLOG_PORT_INTERNAL=${{ secrets.PROLOG_PORT_INTERNAL }}
-
-              # === Flask Backend Configuration ===
-              FLASK_PORT_HOST=${{ secrets.FLASK_PORT_HOST }}
-              FLASK_PORT_INTERNAL=${{ secrets.FLASK_PORT_INTERNAL }}
-
-              # === docker-image===
-              prolog_staging=${{secrets.prolog_staging}}
-              flask_staging=${{secrets.flask_staging}}
-              prefect_staging=${{secrets.prefect_staging}}
-              prefect_deployment_staging=${{secrets.prefect_deployment_staging}}    
-
-          
-      - name: Create dynamic inventory
-        run: |
-          cd ansible-deploy
-          mkdir -p inventory
-          # Get the actual username running the workflow
-          CURRENT_USER=$(whoami)
-          USER_HOME=$HOME
-          cat > inventory/hosts.ini <<EOL
-          [Hypothesis_Remote]
-          localhost ansible_connection=local ansible_user=$CURRENT_USER ansible_become=false ansible_user_dir=$USER_HOME
-          EOL
-          echo "Inventory created for user: $CURRENT_USER"
-          cat inventory/hosts.ini
-          
-      - name: Create dynamic playbook
-        run: |
-          cd ansible-deploy
-          mkdir -p playbooks
-          # Create the deploy_server.yml playbook dynamically
-          cat > playbooks/deploy_server.yml <<EOL
-          ---
-          # deploy_Hypothesis
-          - name: Deploy Hypothesis Service
-            hosts: Hypothesis_Remote
-            tags: Hypothesis_Remote
-            become: no
-            tasks:
-              - include_role:
-                  name: Hypothesis
-                  tasks_from: staging-production-deploy.yml
-          EOL
-          echo "Playbook created:"
-          cat playbooks/deploy_server.yml
-          
-      - name: Ansible configuration
-        run: |
-          cd ansible-deploy
-          # Ensure ansible uses the correct Python interpreter
-          cat > ansible.cfg <<EOL
-          [defaults]
-          interpreter_python = /usr/bin/python3
-          host_key_checking = False
-          inventory = inventory/hosts.ini
-          become = false
-          remote_user = $(whoami)
-          [privilege_escalation]
-          become = false
-          become_method = sudo
-          become_user = root
-          become_ask_pass = false
-          EOL
-          
-      - name: Deploy with Ansible
-        run: |
-          cd ansible-deploy
-          echo "Running as user: $(whoami)"
-          echo "Home directory: $HOME"
-          # Force the correct installation directory
-          ansible-playbook -i inventory/hosts.ini playbooks/deploy_server.yml \
-            --tags "Hypothesis_Remote" \
-            --tags "local_network" \
-            -e "install_dir=$HOME/services/hypothesis-generation-demo" \
-            -e "ansible_user_id=$(whoami)" \
-            -e "ansible_user_dir=$HOME" \
-            -v
+            Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/k8s/staging/api.yaml
+++ b/k8s/staging/api.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hypothesis-api
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hypothesis-api
+  template:
+    metadata:
+      labels:
+        app: hypothesis-api
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: api
+          image: abdum1964/hypothesis-generation-api-service:staging
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5000
+          env:
+            - name: FLASK_ENV
+              value: "development"
+            - name: PREFECT_API_URL
+              value: "http://prefect-service:4200/api"
+            - name: PYTHONPATH
+              value: "/app"
+            - name: DASK_ADDRESS
+              value: "tcp://dask-scheduler:8786"
+            - name: SWIPL_HOST
+              value: "prolog-service"
+            - name: SWIPL_PORT
+              value: "4242"
+            - name: REDIS_URL
+              value: "redis://redis:6379"
+            - name: ENSEMBL_HGNC_MAP
+              value: "/app/data/ensembl_to_hgnc.pkl"
+            - name: HGNC_ENSEMBL_MAP
+              value: "/app/data/hgnc_to_ensembl.pkl"
+            - name: GO_MAP
+              value: "/app/data/go_map.pkl"
+          envFrom:
+            - secretRef:
+                name: hypothesis-secrets
+          command:
+            - "uv"
+            - "run"
+            - "gunicorn"
+            - "src.server:create_app_with_config"
+            - "--workers"
+            - "4"
+            - "--worker-class"
+            - "uvicorn.workers.UvicornWorker"
+            - "--bind"
+            - "0.0.0.0:5000"
+            - "--timeout"
+            - "600"
+            - "--graceful-timeout"
+            - "30"
+            - "--keep-alive"
+            - "5"
+            - "--access-logfile"
+            - "-"
+            - "--error-logfile"
+            - "-"
+          volumeMounts:
+            - name: app-source
+              mountPath: /app
+            - name: app-data
+              mountPath: /app/data
+      volumes:
+        - name: app-source
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo
+        - name: app-data
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo/data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hypothesis-api
+  namespace: hypothesis-staging
+spec:
+  type: NodePort
+  selector:
+    app: hypothesis-api
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30500

--- a/k8s/staging/dask-scheduler.yaml
+++ b/k8s/staging/dask-scheduler.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dask-scheduler
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dask-scheduler
+  template:
+    metadata:
+      labels:
+        app: dask-scheduler
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: dask-scheduler
+          image: abdum1964/hypothesis-generation-dask-scheduler:staging-latest
+          ports:
+            - containerPort: 8786
+            - containerPort: 8787
+          env:
+            - name: PYTHONPATH
+              value: "/app"
+            - name: SKIP_SEED
+              value: "true"
+          command:
+            - "sh"
+            - "-c"
+            - "uv run dask scheduler --host 0.0.0.0 --port 8786 --dashboard-address :8787"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dask-scheduler
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: dask-scheduler
+  ports:
+    - name: scheduler
+      port: 8786
+      targetPort: 8786
+    - name: dashboard
+      port: 8787
+      targetPort: 8787

--- a/k8s/staging/dask-worker.yaml
+++ b/k8s/staging/dask-worker.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dask-worker
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dask-worker
+  template:
+    metadata:
+      labels:
+        app: dask-worker
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      initContainers:
+        - name: wait-for-redis
+          image: redis:7-alpine
+          command: ["sh", "-c", "until redis-cli -h redis ping; do echo waiting for redis; sleep 2; done"]
+      containers:
+        - name: dask-worker
+          image: abdum1964/hypothesis-generation-dask-worker:staging
+          imagePullPolicy: Always
+          env:
+            - name: DASK_ADDRESS
+              value: "tcp://dask-scheduler:8786"
+            - name: PREFECT_API_URL
+              value: "http://prefect-service:4200/api"
+            - name: PYTHONPATH
+              value: "/app"
+            - name: SWIPL_HOST
+              value: "prolog-service"
+            - name: SWIPL_PORT
+              value: "4242"
+            - name: ENSEMBL_HGNC_MAP
+              value: "/app/data/ensembl_to_hgnc.pkl"
+            - name: HGNC_ENSEMBL_MAP
+              value: "/app/data/hgnc_to_ensembl.pkl"
+            - name: GO_MAP
+              value: "/app/data/go_map.pkl"
+            - name: SKIP_SEED
+              value: "true"
+            - name: API_HOST
+              value: "api-service"
+            - name: API_PORT
+              value: "5000"
+            - name: REDIS_URL
+              value: "redis://redis:6379"
+          envFrom:
+            - secretRef:
+                name: hypothesis-secrets
+          command:
+            - "sh"
+            - "-c"
+            - "uv run dask worker tcp://dask-scheduler:8786 --nworkers 4 --nthreads 1 --memory-limit 40GB --preload src.dask_preload"
+          resources:
+            limits:
+              cpu: "8"
+              memory: "32Gi"
+          volumeMounts:
+            - name: app-source
+              mountPath: /app
+            - name: app-data
+              mountPath: /app/data
+      volumes:
+        - name: app-source
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo
+        - name: app-data
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo/data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dask-worker
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: dask-worker
+  ports:
+    - port: 8786
+      targetPort: 8786

--- a/k8s/staging/ingress.yaml
+++ b/k8s/staging/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hypothesis-ingress
+  namespace: hypothesis-staging
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hypothesis-api
+                port:
+                  number: 5000

--- a/k8s/staging/mongo.yaml
+++ b/k8s/staging/mongo.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongo
+  namespace: hypothesis-staging
+spec:
+  selector:
+    matchLabels:
+      app: mongo
+  serviceName: mongo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:latest
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: MONGO_USER
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: MONGO_PASSWORD
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: mongo
+  ports:
+    - port: 27017
+      targetPort: 27017

--- a/k8s/staging/prefect-deployment.yaml
+++ b/k8s/staging/prefect-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefect-deployment
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prefect-deployment
+  template:
+    metadata:
+      labels:
+        app: prefect-deployment
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      initContainers:
+        - name: wait-for-redis
+          image: redis:7-alpine
+          command: ["sh", "-c", "until redis-cli -h redis ping; do echo waiting for redis; sleep 2; done"]
+      containers:
+        - name: prefect-deployment
+          image: abdum1964/hypothesis-generation-prefect-deployment:staging
+          imagePullPolicy: Always
+          env:
+            - name: PREFECT_API_URL
+              value: "http://prefect-service:4200/api"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/opt/flask-venv"
+            - name: DASK_ADDRESS
+              value: "tcp://dask-scheduler:8786"
+            - name: PYTHONPATH
+              value: "/app"
+            - name: ENSEMBL_HGNC_MAP
+              value: "/app/data/ensembl_to_hgnc.pkl"
+            - name: HGNC_ENSEMBL_MAP
+              value: "/app/data/hgnc_to_ensembl.pkl"
+            - name: GO_MAP
+              value: "/app/data/go_map.pkl"
+            - name: API_HOST
+              value: "api-service"
+            - name: API_PORT
+              value: "5000"
+            - name: REDIS_URL
+              value: "redis://redis:6379"
+          envFrom:
+            - secretRef:
+                name: hypothesis-secrets
+          command:
+            - "bash"
+            - "-c"
+            - |
+              uv run prefect work-pool create 'analysis-pool' --type process --overwrite &&
+              uv run prefect work-pool update 'analysis-pool' --concurrency-limit 3 &&
+              uv run prefect work-pool create 'interactive-pool' --type process --overwrite &&
+              uv run prefect work-pool update 'interactive-pool' --concurrency-limit 10 &&
+              uv run prefect concurrency-limit create harmonize_tag 2 || true &&
+              uv run python src/deployments.py --ensembl-hgnc-map /app/data/ensembl_to_hgnc.pkl --hgnc-ensembl-map /app/data/hgnc_to_ensembl.pkl --go-map /app/data/go_map.pkl --swipl-host prolog-service --swipl-port 4242 &&
+              uv run prefect worker start --pool 'analysis-pool' --name 'heavy-worker' &
+              uv run prefect worker start --pool 'interactive-pool' --name 'light-worker' &
+              tail -f /dev/null
+          resources:
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+            - name: app-source
+              mountPath: /app
+            - name: app-data
+              mountPath: /app/data
+      volumes:
+        - name: app-source
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo
+        - name: app-data
+          hostPath:
+            path: /mnt/hdd_1/tesnim/hypothesis-generation_demo/data

--- a/k8s/staging/prefect-postgres.yaml
+++ b/k8s/staging/prefect-postgres.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prefect-postgres
+  namespace: hypothesis-staging
+spec:
+  selector:
+    matchLabels:
+      app: prefect-postgres
+  serviceName: prefect-postgres
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prefect-postgres
+    spec:
+      containers:
+        - name: prefect-postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: PREFECT_DB_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: PREFECT_DB_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: PREFECT_DB_NAME
+          volumeMounts:
+            - name: prefect-postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: prefect-postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prefect-postgres
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: prefect-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/staging/prefect-service.yaml
+++ b/k8s/staging/prefect-service.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefect-service
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prefect-service
+  template:
+    metadata:
+      labels:
+        app: prefect-service
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: prefect-service
+          image: abdum1964/hypothesis-generation-prefect-service:staging
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4200
+          env:
+            - name: PREFECT_API_URL
+              value: "http://prefect-service:4200/api"
+            - name: PREFECT_UI_API_URL
+              value: "https://dev.rejuve.bio:5054/api"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/opt/prefect-venv"
+            - name: DASK_ADDRESS
+              value: "tcp://dask-scheduler:8786"
+            - name: PREFECT_API_DATABASE_CONNECTION_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hypothesis-secrets
+                  key: PREFECT_API_DATABASE_CONNECTION_URL
+          envFrom:
+            - secretRef:
+                name: hypothesis-secrets
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prefect-service
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: prefect-service
+  ports:
+    - port: 4200
+      targetPort: 4200

--- a/k8s/staging/prolog.yaml
+++ b/k8s/staging/prolog.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prolog-service
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prolog-service
+  template:
+    metadata:
+      labels:
+        app: prolog-service
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: prolog
+          image: abdum1964/hypothesis-generation-prolog-service:staging-latest
+          ports:
+            - containerPort: 4242
+          volumeMounts:
+            - name: prolog-out-v2
+              mountPath: /mnt/prolog_out_v2
+            - name: prolog-out-v3
+              mountPath: /mnt/prolog_out_v3
+      volumes:
+        - name: prolog-out-v2
+          hostPath:
+            path: /mnt/hdd_1/biocypher-kg/output/human/prolog_out_v2
+        - name: prolog-out-v3
+          hostPath:
+            path: /mnt/hdd_1/biocypher-kg/output/human/prolog_out_v3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prolog-service
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: prolog-service
+  ports:
+    - port: 4242
+      targetPort: 4242

--- a/k8s/staging/redis.yaml
+++ b/k8s/staging/redis.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: hypothesis-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: hypothesis-staging
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
## Summary
Updated the CD pipeline to handle deployments using Kubernetes instead of the previous approach. 
Created Kubernetes pod configurations for all services to ensure proper orchestration and scalability.

## Changes
- Updated `cd-staging-deployment.yml` workflow to deploy to Kubernetes
- Created Kubernetes manifests (pods/deployments) for all services
- Added k8s configuration files under the `k8s/` directory

## Type of Change
- [x] CI/CD update
- [x] Infrastructure change

## Services Covered
- api-service
- dask-scheduler / dask-worker
- mongo
- prefect-service / prefect-deployment
- prolog-service
- redis

## Testing
- Verified deployment workflow triggers correctly
- All services have corresponding Kubernetes configurations