### PR TITLE
 feat: email notifications for analysis pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "dask[distributed]",
     "statsmodels>=0.14.0",
     "dependency-injector>=4.41",
+    "fastapi-mail>=1.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -29,3 +29,12 @@ async def get_current_user_id(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Token is invalid!",
         )
+async def get_current_user_email(
+    creds: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> str | None:
+    """FastAPI dependency: extract email from JWT token if present."""
+    try:
+        data = _decode(creds.credentials)
+        return data.get("email")
+    except Exception:
+        return None

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -35,6 +35,7 @@ from src.db import (
     ProjectHandler,
 )
 from src.tasks.project import count_gwas_records, get_project_with_full_data
+from src.api.auth import get_current_user_id, get_current_user_email
 from src.run_deployment import invoke_analysis_pipeline_deployment
 from src.utils import (
     allowed_file,
@@ -208,6 +209,7 @@ async def post_analysis_pipeline(
     config: Config = Depends(get_config),
     storage=Depends(get_storage),
     gwas_library: GWASLibraryHandler = Depends(get_gwas_library_handler),
+    current_user_email: str | None = Depends(get_current_user_email),
 ):
     try:
         form = await request.form()
@@ -535,6 +537,7 @@ async def post_analysis_pipeline(
             population=population,
             ref_genome=ref_genome,
             analysis_parameters=analysis_parameters,
+            user_email=current_user_email,
         )
 
         metadata_dir = os.path.join("data", "metadata", str(current_user_id))
@@ -588,6 +591,8 @@ async def post_analysis_pipeline(
                 file_source_download_url=_source_download_url,
                 file_minio_cache_key=_minio_cache_key,
                 file_gwas_library_id=_gwas_library_id,
+                user_email=current_user_email,      
+                project_name=project_name,          
             ),
         )
 

--- a/src/app.py
+++ b/src/app.py
@@ -19,7 +19,6 @@ from src.socketio_instance import sio
 from src.services.socketio_relay import relay_subscribe_forever
 from src.services.status_tracker import StatusTracker
 from src.api import router
-from src.api.dependencies import init_deps
 from src.services.mail import init_mail
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,10 @@ from src.socketio_instance import sio
 from src.services.socketio_relay import relay_subscribe_forever
 from src.services.status_tracker import StatusTracker
 from src.api import router
+from src.api.dependencies import init_deps
+from src.services.mail import init_mail
+
+
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -59,6 +63,20 @@ def create_app(config: Config) -> python_socketio.ASGIApp:
 
         status_tracker = StatusTracker()
         status_tracker.initialize(container.task_handler(), redis_url=config.redis_url)
+        if config.mail_server:
+            init_mail(
+                mail_username=config.mail_username,
+                mail_password=config.mail_password,
+                mail_from=config.mail_from,
+                mail_server=config.mail_server,
+                mail_port=config.mail_port,
+                mail_tls=config.mail_tls,
+                mail_ssl=config.mail_ssl,
+            )
+            logger.info("Mail service initialized")
+        else:
+            logger.warning("MAIL_SERVER not set - email notifications disabled")
+
 
         relay_task: asyncio.Task[None] | None = None
         if config.redis_url:

--- a/src/config.py
+++ b/src/config.py
@@ -45,6 +45,14 @@ class Config:
         self.ldsc_cts_file = "data/cts/cell_types_available.cts"
         self.cell_ontology_tsv = "data/Cell_ontology.tsv"
         self.catlas_abc_aliases_tsv = "data/catlas_abc_cell_type_aliases.tsv"
+        self.mail_username = ""
+        self.mail_password = ""
+        self.mail_from = ""
+        self.mail_server = ""
+        self.mail_port = 587
+        self.mail_tls = True
+        self.mail_ssl = False
+        
 
     @classmethod
     def from_args(cls, args):
@@ -109,6 +117,13 @@ class Config:
         config.catlas_abc_aliases_tsv = os.getenv(
             "CATLAS_ABC_ALIASES_TSV", "data/catlas_abc_cell_type_aliases.tsv"
         )
+        config.mail_username = os.getenv("MAIL_USERNAME", "")
+        config.mail_password = os.getenv("MAIL_PASSWORD", "")
+        config.mail_from = os.getenv("MAIL_FROM", "")
+        config.mail_server = os.getenv("MAIL_SERVER", "")
+        config.mail_port = int(os.getenv("MAIL_PORT", "587"))
+        config.mail_tls = os.getenv("MAIL_TLS", "true").lower() == "true"
+        config.mail_ssl = os.getenv("MAIL_SSL", "false").lower() == "true"
         return config
 
     def get_harmonizer_ref_dir(self, ref_genome):

--- a/src/db/project_handler.py
+++ b/src/db/project_handler.py
@@ -24,7 +24,7 @@ class ProjectHandler(BaseHandler):
         self.analysis_results_collection = self.db['analysis_results']
         self.file_metadata_collection = self.db['file_metadata']
     
-    def create_project(self, user_id, name, gwas_file_id, phenotype,population, ref_genome, analysis_parameters=None):
+    def create_project(self, user_id, name, gwas_file_id, phenotype,population, ref_genome, analysis_parameters=None, user_email=None):
         """Create a new project"""
         project_data = {
             'user_id': user_id,
@@ -36,7 +36,8 @@ class ProjectHandler(BaseHandler):
             'gwas_file_id': gwas_file_id,
             'population': population,
             'ref_genome': ref_genome,
-            'analysis_parameters': analysis_parameters or {}
+            'analysis_parameters': analysis_parameters or {},
+            "user_email": user_email,
         }
         result = self.projects_collection.insert_one(project_data)
         return str(result.inserted_id)

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -7,6 +7,9 @@ from loguru import logger
 from prefect import flow
 from prefect.runtime import flow_run as _prefect_flow_run
 from prefect_dask import DaskTaskRunner
+from src.services.mail import send_email
+from src.utils import get_deps
+import asyncio
 
 from src.config import Config
 from src.tasks import (
@@ -34,6 +37,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
                            population="EUR", batch_size=5, max_workers=3,
                            maf_threshold=0.01, seed=42, window=2000, L=-1,
                            coverage=0.95, min_abs_corr=0.5, sample_size=None,
+                           user_email: str | None = None, project_name: str | None = None,
                            file_metadata_id=None, file_needs_processing=False,
                            file_storage_key=None, file_id_new=None,
                            file_source_minio_path=None, file_source_download_url=None,
@@ -293,6 +297,25 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
                 "ldsc_status": ldsc_status
             }
             save_analysis_state_task.submit(user_id, project_id, completed_state).result()
+
+            # Send completion email if we have an address
+            if user_email:
+                display_name = project_name or project_id
+                try:
+                    asyncio.run(send_email(
+                        subject="Your analysis is complete",
+                        recipients=[user_email],
+                        body=(
+                            f"Your analysis for project '{display_name}' has completed successfully.\n\n"
+                            "You can now view your results in the platform."
+                        ),
+                    ))
+                    logger.info(f"[PIPELINE] Completion email sent to {user_email}")
+                except Exception as mail_e:
+                    # Email failure must never fail the pipeline
+                    logger.error(f"[PIPELINE] Could not send completion email: {mail_e}")
+            else:
+                logger.info("[PIPELINE] No user_email provided — skipping completion notification")
 
             logger.info(f"[PIPELINE] Analysis completed successfully!")
             logger.info(f"[PIPELINE] - Total variants: {total_variants}")

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -7,9 +7,8 @@ from loguru import logger
 from prefect import flow
 from prefect.runtime import flow_run as _prefect_flow_run
 from prefect_dask import DaskTaskRunner
-from src.services.mail import send_email
 from src.utils import get_deps
-import asyncio
+from src.services.mail import send_pipeline_notification
 
 from src.config import Config
 from src.tasks import (
@@ -28,47 +27,7 @@ from src.tasks import (
 )
 
 
-def _send_pipeline_notification(
-    user_email: str | None,
-    project_name: str | None,
-    project_id: str,
-    *,
-    success: bool,
-    detail: str | None = None,
-) -> None:
-    """Send a success or failure email. Never raises."""
-    if not user_email:
-        logger.info("[PIPELINE] No user_email provided — skipping notification")
-        return
 
-    display_name = project_name or project_id
-    if success:
-        subject = "Your analysis is complete"
-        body = (
-            f"Your analysis for project '{display_name}' has completed successfully.\n\n"
-            "You can now view your results in the platform."
-        )
-        ok_log = f"Completion email sent to {user_email}"
-        err_log = "Could not send completion email"
-    else:
-        subject = "Your analysis failed"
-        reason = detail or "An error occurred during analysis."
-        body = (
-            f"Your analysis for project '{display_name}' did not complete successfully.\n\n"
-            f"Details: {reason}\n\n"
-            "Please try again or contact support if the problem persists."
-        )
-        ok_log = f"Failure notification email sent to {user_email}"
-        err_log = "Could not send failure notification email"
-
-    try:
-        asyncio.run(send_email(subject=subject, recipients=[user_email], body=body))
-        logger.info(f"[PIPELINE] {ok_log}")
-    except Exception as mail_e:
-        logger.error(f"[PIPELINE] {err_log}: {mail_e}")
-
-
-### Analysis Pipeline Flow
 @flow(log_prints=True,
     persist_result=False,
     task_runner=DaskTaskRunner(address=os.getenv("DASK_ADDRESS"))
@@ -213,7 +172,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
                 "message": "COJO analysis failed - no independent signals found",
             }
             save_analysis_state_task.submit(user_id, project_id, failed_state).result()
-            _send_pipeline_notification(
+            send_pipeline_notification(
                 user_email, project_name, project_id,
                 success=False, detail=failed_state["message"],
             )
@@ -342,7 +301,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             }
             save_analysis_state_task.submit(user_id, project_id, completed_state).result()
 
-            _send_pipeline_notification(user_email, project_name, project_id, success=True)
+            send_pipeline_notification(user_email, project_name, project_id, success=True)
 
             logger.info(f"[PIPELINE] Analysis completed successfully!")
             logger.info(f"[PIPELINE] - Total variants: {total_variants}")
@@ -382,7 +341,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             save_analysis_state_task.submit(user_id, project_id, failed_state).result()
         except Exception as state_e:
             logger.error(f"[PIPELINE] Failed to save error state: {str(state_e)}")
-        _send_pipeline_notification(
+        send_pipeline_notification(
             user_email, project_name, project_id,
             success=False, detail=str(e),
         )

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -28,6 +28,46 @@ from src.tasks import (
 )
 
 
+def _send_pipeline_notification(
+    user_email: str | None,
+    project_name: str | None,
+    project_id: str,
+    *,
+    success: bool,
+    detail: str | None = None,
+) -> None:
+    """Send a success or failure email. Never raises."""
+    if not user_email:
+        logger.info("[PIPELINE] No user_email provided — skipping notification")
+        return
+
+    display_name = project_name or project_id
+    if success:
+        subject = "Your analysis is complete"
+        body = (
+            f"Your analysis for project '{display_name}' has completed successfully.\n\n"
+            "You can now view your results in the platform."
+        )
+        ok_log = f"Completion email sent to {user_email}"
+        err_log = "Could not send completion email"
+    else:
+        subject = "Your analysis failed"
+        reason = detail or "An error occurred during analysis."
+        body = (
+            f"Your analysis for project '{display_name}' did not complete successfully.\n\n"
+            f"Details: {reason}\n\n"
+            "Please try again or contact support if the problem persists."
+        )
+        ok_log = f"Failure notification email sent to {user_email}"
+        err_log = "Could not send failure notification email"
+
+    try:
+        asyncio.run(send_email(subject=subject, recipients=[user_email], body=body))
+        logger.info(f"[PIPELINE] {ok_log}")
+    except Exception as mail_e:
+        logger.error(f"[PIPELINE] {err_log}: {mail_e}")
+
+
 ### Analysis Pipeline Flow
 @flow(log_prints=True,
     persist_result=False,
@@ -173,6 +213,10 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
                 "message": "COJO analysis failed - no independent signals found",
             }
             save_analysis_state_task.submit(user_id, project_id, failed_state).result()
+            _send_pipeline_notification(
+                user_email, project_name, project_id,
+                success=False, detail=failed_state["message"],
+            )
             return None
 
         # Update analysis state after COJO
@@ -298,24 +342,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             }
             save_analysis_state_task.submit(user_id, project_id, completed_state).result()
 
-            # Send completion email if we have an address
-            if user_email:
-                display_name = project_name or project_id
-                try:
-                    asyncio.run(send_email(
-                        subject="Your analysis is complete",
-                        recipients=[user_email],
-                        body=(
-                            f"Your analysis for project '{display_name}' has completed successfully.\n\n"
-                            "You can now view your results in the platform."
-                        ),
-                    ))
-                    logger.info(f"[PIPELINE] Completion email sent to {user_email}")
-                except Exception as mail_e:
-                    # Email failure must never fail the pipeline
-                    logger.error(f"[PIPELINE] Could not send completion email: {mail_e}")
-            else:
-                logger.info("[PIPELINE] No user_email provided — skipping completion notification")
+            _send_pipeline_notification(user_email, project_name, project_id, success=True)
 
             logger.info(f"[PIPELINE] Analysis completed successfully!")
             logger.info(f"[PIPELINE] - Total variants: {total_variants}")
@@ -355,4 +382,8 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             save_analysis_state_task.submit(user_id, project_id, failed_state).result()
         except Exception as state_e:
             logger.error(f"[PIPELINE] Failed to save error state: {str(state_e)}")
+        _send_pipeline_notification(
+            user_email, project_name, project_id,
+            success=False, detail=str(e),
+        )
         raise

--- a/src/run_deployment.py
+++ b/src/run_deployment.py
@@ -22,6 +22,8 @@ def invoke_analysis_pipeline_deployment(
     user_id, project_id, gwas_file_path=None, ref_genome="GRCh38", population="EUR",
     batch_size=5, max_workers=3, maf_threshold=0.01, seed=42, window=2000, L=-1,
     coverage=0.95, min_abs_corr=0.5, sample_size=None,
+    user_email: str | None = None,
+    project_name: str | None = None,
     file_metadata_id=None, file_needs_processing=False,
     file_storage_key=None, file_id_new=None,
     file_source_minio_path=None, file_source_download_url=None,
@@ -52,6 +54,8 @@ def invoke_analysis_pipeline_deployment(
             "file_source_download_url": file_source_download_url,
             "file_minio_cache_key": file_minio_cache_key,
             "file_gwas_library_id": file_gwas_library_id,
+            "user_email": user_email,
+            "project_name": project_name,
         },
         timeout=0
     )

--- a/src/services/mail.py
+++ b/src/services/mail.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+
+from fastapi_mail import ConnectionConfig, FastMail, MessageSchema
+from loguru import logger
+
+
+def _build_fast_mail() -> FastMail | None:
+    """Build a FastMail instance from environment variables. Returns None if MAIL_SERVER is not set."""
+    mail_server = os.getenv("MAIL_SERVER", "")
+    if not mail_server:
+        return None
+    cfg = ConnectionConfig(
+        MAIL_USERNAME=os.getenv("MAIL_USERNAME", ""),
+        MAIL_PASSWORD=os.getenv("MAIL_PASSWORD", ""),
+        MAIL_FROM=os.getenv("MAIL_FROM", ""),
+        MAIL_PORT=int(os.getenv("MAIL_PORT", "587")),
+        MAIL_SERVER=mail_server,
+        MAIL_STARTTLS=os.getenv("MAIL_TLS", "true").lower() == "true",
+        MAIL_SSL_TLS=os.getenv("MAIL_SSL", "false").lower() == "true",
+        USE_CREDENTIALS=True,
+    )
+    return FastMail(cfg)
+
+
+# Module-level instance — set by init_mail() in the API process.
+# Worker processes that never call init_mail() fall back to _build_fast_mail().
+_fast_mail: FastMail | None = None
+
+
+def init_mail(
+    mail_username: str,
+    mail_password: str,
+    mail_from: str,
+    mail_server: str,
+    mail_port: int = 587,
+    mail_tls: bool = True,
+    mail_ssl: bool = False,
+) -> None:
+    global _fast_mail
+    if not mail_server:
+        logger.warning("init_mail called with empty MAIL_SERVER — email disabled")
+        return
+    cfg = ConnectionConfig(
+        MAIL_USERNAME=mail_username,
+        MAIL_PASSWORD=mail_password,
+        MAIL_FROM=mail_from,
+        MAIL_PORT=mail_port,
+        MAIL_SERVER=mail_server,
+        MAIL_STARTTLS=mail_tls,
+        MAIL_SSL_TLS=mail_ssl,
+        USE_CREDENTIALS=True,
+    )
+    _fast_mail = FastMail(cfg)
+    logger.info("Mail service initialized")
+
+
+async def send_email(subject: str, recipients: list[str], body: str) -> None:
+    """
+    Send a plain-text email.
+
+    Safe to call from both the API process (where init_mail was called)
+    and from Prefect/Dask worker processes (where it was not — falls back
+    to building FastMail from env vars on demand).
+    """
+    if not recipients:
+        logger.warning("send_email called with empty recipients list — skipping")
+        return
+
+    fm = _fast_mail or _build_fast_mail()
+    if fm is None:
+        logger.warning("MAIL_SERVER not configured — skipping email: %s", subject)
+        return
+
+    try:
+        msg = MessageSchema(
+            subject=subject,
+            recipients=recipients,
+            body=body,
+            subtype="plain",
+        )
+        await fm.send_message(msg)
+        logger.info("Email sent to {} | subject: {}", recipients, subject)
+    except Exception as exc:
+        logger.error("Failed to send email to {}: {}", recipients, exc)

--- a/src/services/mail/__init__.py
+++ b/src/services/mail/__init__.py
@@ -1,0 +1,4 @@
+from src.services.mail.client import init_mail, send_email
+from src.services.mail.notifications import send_pipeline_notification
+
+__all__ = ["init_mail", "send_email", "send_pipeline_notification"]

--- a/src/services/mail/client.py
+++ b/src/services/mail/client.py
@@ -5,13 +5,14 @@ import os
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema
 from loguru import logger
 
+_fast_mail: FastMail | None = None
+
 
 def _build_fast_mail() -> FastMail | None:
-    """Build a FastMail instance from environment variables. Returns None if MAIL_SERVER is not set."""
     mail_server = os.getenv("MAIL_SERVER", "")
     if not mail_server:
         return None
-    cfg = ConnectionConfig(
+    return FastMail(ConnectionConfig(
         MAIL_USERNAME=os.getenv("MAIL_USERNAME", ""),
         MAIL_PASSWORD=os.getenv("MAIL_PASSWORD", ""),
         MAIL_FROM=os.getenv("MAIL_FROM", ""),
@@ -20,13 +21,7 @@ def _build_fast_mail() -> FastMail | None:
         MAIL_STARTTLS=os.getenv("MAIL_TLS", "true").lower() == "true",
         MAIL_SSL_TLS=os.getenv("MAIL_SSL", "false").lower() == "true",
         USE_CREDENTIALS=True,
-    )
-    return FastMail(cfg)
-
-
-# Module-level instance — set by init_mail() in the API process.
-# Worker processes that never call init_mail() fall back to _build_fast_mail().
-_fast_mail: FastMail | None = None
+    ))
 
 
 def init_mail(
@@ -42,7 +37,7 @@ def init_mail(
     if not mail_server:
         logger.warning("init_mail called with empty MAIL_SERVER — email disabled")
         return
-    cfg = ConnectionConfig(
+    _fast_mail = FastMail(ConnectionConfig(
         MAIL_USERNAME=mail_username,
         MAIL_PASSWORD=mail_password,
         MAIL_FROM=mail_from,
@@ -51,19 +46,18 @@ def init_mail(
         MAIL_STARTTLS=mail_tls,
         MAIL_SSL_TLS=mail_ssl,
         USE_CREDENTIALS=True,
-    )
-    _fast_mail = FastMail(cfg)
+    ))
     logger.info("Mail service initialized")
 
 
-async def send_email(subject: str, recipients: list[str], body: str) -> None:
-    """
-    Send a plain-text email.
-
-    Safe to call from both the API process (where init_mail was called)
-    and from Prefect/Dask worker processes (where it was not — falls back
-    to building FastMail from env vars on demand).
-    """
+async def send_email(
+    subject: str,
+    recipients: list[str],
+    body: str,
+    subtype: str = "html",
+) -> None:
+    """Send an email from the API process or a Prefect/Dask worker.
+    Falls back to building FastMail from env vars if init_mail was never called."""
     if not recipients:
         logger.warning("send_email called with empty recipients list — skipping")
         return
@@ -74,13 +68,12 @@ async def send_email(subject: str, recipients: list[str], body: str) -> None:
         return
 
     try:
-        msg = MessageSchema(
+        await fm.send_message(MessageSchema(
             subject=subject,
             recipients=recipients,
             body=body,
-            subtype="plain",
-        )
-        await fm.send_message(msg)
+            subtype=subtype,
+        ))
         logger.info("Email sent to {} | subject: {}", recipients, subject)
     except Exception as exc:
         logger.error("Failed to send email to {}: {}", recipients, exc)

--- a/src/services/mail/notifications.py
+++ b/src/services/mail/notifications.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from loguru import logger
+
+from src.services.mail.client import send_email
+from src.services.mail.templates import build_complete_email, build_failed_email
+
+
+def send_pipeline_notification(
+    user_email: str | None,
+    project_name: str | None,
+    project_id: str,
+    *,
+    success: bool,
+    detail: str | None = None,
+) -> None:
+    """Send a completion or failure notification for an analysis pipeline run. Never raises."""
+    if not user_email:
+        logger.info("[PIPELINE] No user_email provided — skipping notification")
+        return
+
+    if success:
+        payload = build_complete_email(
+            to=user_email,
+            project_name=project_name or project_id,
+            project_id=project_id,
+            app_base_url=os.getenv("APP_BASE_URL", "https://dev.rejuve.bio"),
+        )
+        ok_log = f"Completion email sent to {user_email}"
+        err_log = "Could not send completion email"
+    else:
+        payload = build_failed_email(
+            to=user_email,
+            project_name=project_name or project_id,
+            error=detail,
+        )
+        ok_log = f"Failure notification email sent to {user_email}"
+        err_log = "Could not send failure notification email"
+
+    try:
+        asyncio.run(send_email(subject=payload.subject, recipients=[user_email], body=payload.body_html))
+        logger.info(f"[PIPELINE] {ok_log}")
+    except Exception as mail_e:
+        logger.error(f"[PIPELINE] {err_log}: {mail_e}")

--- a/src/services/mail/templates.py
+++ b/src/services/mail/templates.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class EmailPayload:
+    to: str
+    subject: str
+    body_html: str
+    body_text: str
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d · %H:%M UTC")
+
+
+def _build_html(
+    headline: str,
+    top_bar_color: str,
+    first_name: str,
+    intro: str,
+    project_name: str,
+    badge_style: str,
+    status_label: str,
+    time_label: str,
+    timestamp: str,
+    extra_block: str,
+    cta_block: str,
+    footnote: str,
+) -> str:
+    return (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1"></head>'
+        '<body style="margin:0;padding:0;background:#f4f4f7;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">'
+        '<table width="100%" cellpadding="0" cellspacing="0" '
+        'style="background:#f4f4f7;padding:32px 16px;">'
+        '<tr><td align="center">'
+        '<table width="620" cellpadding="0" cellspacing="0" '
+        'style="background:#ffffff;border:0.5px solid #e2e2e6;border-radius:12px;'
+        'overflow:hidden;max-width:620px;width:100%;">'
+
+        f'<tr><td style="height:5px;background:{top_bar_color};font-size:0;line-height:0;">&nbsp;</td></tr>'
+
+        '<tr><td style="padding:24px 32px 20px;border-bottom:0.5px solid #e2e2e6;">'
+        '<p style="margin:0 0 6px;font-size:11px;letter-spacing:0.12em;font-weight:500;color:#5a4fcf;">REJUVE BIOTECH</p>'
+        f'<p style="margin:0;font-size:22px;font-weight:500;color:#111111;letter-spacing:-0.01em;">{headline}</p>'
+        '</td></tr>'
+
+        '<tr><td style="padding:24px 32px;">'
+        f'<p style="margin:0 0 10px;font-size:14px;color:#111111;line-height:1.65;">Hi {first_name},</p>'
+        f'<p style="margin:0 0 20px;font-size:14px;color:#555555;line-height:1.65;">{intro}</p>'
+
+        '<table width="100%" cellpadding="0" cellspacing="0" '
+        'style="background:#f8f8fa;border:0.5px solid #e2e2e6;border-radius:8px;margin-bottom:20px;">'
+
+        '<tr><td style="padding:10px 16px;border-bottom:0.5px solid #e2e2e6;">'
+        '<table width="100%"><tr>'
+        '<td style="font-size:12px;color:#777777;">Project</td>'
+        f'<td align="right" style="font-size:12px;color:#111111;font-weight:500;">{project_name}</td>'
+        '</tr></table></td></tr>'
+
+        '<tr><td style="padding:10px 16px;border-bottom:0.5px solid #e2e2e6;">'
+        '<table width="100%"><tr>'
+        '<td style="font-size:12px;color:#777777;">Status</td>'
+        f'<td align="right"><span style="font-size:11px;font-weight:500;padding:3px 10px;border-radius:6px;{badge_style}">{status_label}</span></td>'
+        '</tr></table></td></tr>'
+
+        '<tr><td style="padding:10px 16px;">'
+        '<table width="100%"><tr>'
+        f'<td style="font-size:12px;color:#777777;">{time_label}</td>'
+        f'<td align="right" style="font-size:12px;color:#111111;">{timestamp}</td>'
+        '</tr></table></td></tr>'
+
+        '</table>'
+
+        f'{extra_block}'
+        f'{cta_block}'
+
+        f'<p style="margin:0;font-size:12px;color:#999999;line-height:1.6;">{footnote}</p>'
+        '</td></tr>'
+
+        '<tr><td style="border-top:0.5px solid #e2e2e6;padding:12px 32px;background:#f8f8fa;">'
+        '<table width="100%"><tr>'
+        '<td style="font-size:11px;color:#999999;">Rejuve Biotech · Hypothesis Generation</td>'
+        '<td align="right" style="font-size:11px;color:#999999;">© 2026</td>'
+        '</tr></table></td></tr>'
+
+        '</table></td></tr></table></body></html>'
+    )
+
+
+def _cta(url: str, label: str) -> str:
+    return (
+        f'<a href="{url}" style="display:inline-block;background:#5a4fcf;color:#ffffff;'
+        'text-decoration:none;padding:10px 22px;border-radius:8px;'
+        f'font-size:13px;font-weight:500;margin-bottom:20px;">{label}</a>'
+    )
+
+
+def _message_block(message: str) -> str:
+    return (
+        '<table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:20px;">'
+        '<tr><td style="border-left:3px solid #e24b4a;padding:14px 18px;background:#fff8f8;border-radius:0 6px 6px 0;">'
+        '<p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#a32d2d;'
+        'text-transform:uppercase;letter-spacing:0.08em;">What went wrong</p>'
+        f'<p style="margin:0;font-size:13px;color:#333333;line-height:1.65;">{message}</p>'
+        '</td></tr></table>'
+    )
+
+
+def _get_user_friendly_error(raw: str | None) -> str:
+    if not raw:
+        return "An unexpected error occurred during analysis. Please contact your administrator if the issue persists."
+
+    msg = raw.lower()
+
+    if "harmoniz" in msg or "nextflow" in msg:
+        return (
+            "The pipeline failed during GWAS harmonization. "
+            "Please check that your input file is correctly formatted and try again."
+        )
+    if "filter" in msg or "significant" in msg:
+        return (
+            "No genome-wide significant variants were found after filtering. "
+            "Your GWAS file may not contain variants that pass the significance threshold."
+        )
+    if "cojo" in msg or "independent signal" in msg or "out-of-bounds" in msg or "indexer" in msg:
+        return (
+            "No independent signals were found after variant filtering. "
+            "Try adjusting your MAF threshold or significance cutoff."
+        )
+    if "fine" in msg or "susie" in msg or "finemap" in msg or "fine-mapping" in msg:
+        return (
+            "The fine-mapping step did not complete. "
+            "This may be due to insufficient variants in one or more genomic regions."
+        )
+    if "ldsc" in msg or "heritability" in msg or "tissue" in msg:
+        return (
+            "The tissue enrichment analysis (LDSC) did not complete successfully. "
+            "This may be a temporary issue with the reference data."
+        )
+    if "memory" in msg or "oom" in msg or "killed" in msg or "timeout" in msg:
+        return "The pipeline timed out. This may be a temporary issue — please try again."
+    if "storage" in msg or "minio" in msg or "download" in msg or "upload" in msg:
+        return (
+            "There was a problem accessing or downloading your GWAS file. "
+            "Please verify the file is available and try again."
+        )
+
+    return "An unexpected error occurred during analysis. Please contact your administrator if the issue persists."
+
+
+def build_complete_email(
+    to: str,
+    project_name: str,
+    project_id: str,
+    app_base_url: str,
+    first_name: str = "there",
+) -> EmailPayload:
+    result_url = f"{app_base_url.rstrip('/')}/hypothesis/{project_id}"
+    ts = _now_utc()
+
+    html = _build_html(
+        headline="Analysis complete",
+        top_bar_color="#5a4fcf",
+        first_name=first_name,
+        intro=(
+            f"Your analysis for project <strong style='font-weight:500;color:#111111;'>"
+            f"{project_name}</strong> has finished running successfully. "
+            "Your results are ready to review."
+        ),
+        project_name=project_name,
+        badge_style="background:#eaf3de;color:#3b6d11;",
+        status_label="Completed",
+        time_label="Finished at",
+        timestamp=ts,
+        extra_block="",
+        cta_block=_cta(result_url, "View results →"),
+        footnote=(
+            "You're receiving this because you triggered an analysis run on the "
+            "Hypothesis Generation platform. If you didn't expect this, you can ignore it."
+        ),
+    )
+
+    plain = (
+        f"REJUVE BIOTECH — Analysis complete\n"
+        f"{'─' * 40}\n\n"
+        f"Hi {first_name},\n\n"
+        f"Your analysis for '{project_name}' completed successfully.\n\n"
+        f"Project : {project_name}\n"
+        f"Status  : Completed\n"
+        f"Time    : {ts}\n\n"
+        f"View results: {result_url}\n\n"
+        "Rejuve Biotech · Hypothesis Generation Platform"
+    )
+
+    return EmailPayload(
+        to=to,
+        subject=f"Rejuve Biotech | Analysis complete — {project_name}",
+        body_html=html,
+        body_text=plain,
+    )
+
+
+def build_failed_email(
+    to: str,
+    project_name: str,
+    error: Optional[str] = None,
+    first_name: str = "there",
+) -> EmailPayload:
+    ts = _now_utc()
+    friendly = _get_user_friendly_error(error)
+
+    html = _build_html(
+        headline="Analysis failed",
+        top_bar_color="#e24b4a",
+        first_name=first_name,
+        intro=(
+            f"Unfortunately the analysis for project <strong style='font-weight:500;color:#111111;'>"
+            f"{project_name}</strong> did not complete successfully."
+        ),
+        project_name=project_name,
+        badge_style="background:#fcebeb;color:#a32d2d;",
+        status_label="Failed",
+        time_label="Failed at",
+        timestamp=ts,
+        extra_block=_message_block(friendly),
+        cta_block="",
+        footnote="Please retry the analysis or contact your administrator if the issue persists.",
+    )
+
+    plain = (
+        f"REJUVE BIOTECH — Analysis failed\n"
+        f"{'─' * 40}\n\n"
+        f"Hi {first_name},\n\n"
+        f"The analysis for project '{project_name}' did not complete.\n\n"
+        f"Project : {project_name}\n"
+        f"Status  : Failed\n"
+        f"Time    : {ts}\n"
+        f"Details : {friendly}\n\n"
+        "Please retry or contact your administrator.\n\n"
+        "Rejuve Biotech · Hypothesis Generation Platform"
+    )
+
+    return EmailPayload(
+        to=to,
+        subject=f"Rejuve Biotech | Analysis failed — {project_name}",
+        body_html=html,
+        body_text=plain,
+    )

--- a/src/services/mail/templates.py
+++ b/src/services/mail/templates.py
@@ -17,99 +17,19 @@ def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d · %H:%M UTC")
 
 
-def _build_html(
-    headline: str,
-    top_bar_color: str,
-    first_name: str,
-    intro: str,
-    project_name: str,
-    badge_style: str,
-    status_label: str,
-    time_label: str,
-    timestamp: str,
-    extra_block: str,
-    cta_block: str,
-    footnote: str,
-) -> str:
-    return (
-        '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
-        '<meta name="viewport" content="width=device-width,initial-scale=1"></head>'
-        '<body style="margin:0;padding:0;background:#f4f4f7;'
-        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">'
-        '<table width="100%" cellpadding="0" cellspacing="0" '
-        'style="background:#f4f4f7;padding:32px 16px;">'
-        '<tr><td align="center">'
-        '<table width="620" cellpadding="0" cellspacing="0" '
-        'style="background:#ffffff;border:0.5px solid #e2e2e6;border-radius:12px;'
-        'overflow:hidden;max-width:620px;width:100%;">'
+_BASE_URL = "https://dev.rejuve.bio/assets/email"
 
-        f'<tr><td style="height:5px;background:{top_bar_color};font-size:0;line-height:0;">&nbsp;</td></tr>'
+_ICON_SUCCESS = (
+    f'<img src="{_BASE_URL}/dna-complete.png" '
+    'width="160" height="160" alt="" '
+    'style="display:block;margin:0 auto;" />'
+)
 
-        '<tr><td style="padding:24px 32px 20px;border-bottom:0.5px solid #e2e2e6;">'
-        '<p style="margin:0 0 6px;font-size:11px;letter-spacing:0.12em;font-weight:500;color:#5a4fcf;">REJUVE BIOTECH</p>'
-        f'<p style="margin:0;font-size:22px;font-weight:500;color:#111111;letter-spacing:-0.01em;">{headline}</p>'
-        '</td></tr>'
-
-        '<tr><td style="padding:24px 32px;">'
-        f'<p style="margin:0 0 10px;font-size:14px;color:#111111;line-height:1.65;">Hi {first_name},</p>'
-        f'<p style="margin:0 0 20px;font-size:14px;color:#555555;line-height:1.65;">{intro}</p>'
-
-        '<table width="100%" cellpadding="0" cellspacing="0" '
-        'style="background:#f8f8fa;border:0.5px solid #e2e2e6;border-radius:8px;margin-bottom:20px;">'
-
-        '<tr><td style="padding:10px 16px;border-bottom:0.5px solid #e2e2e6;">'
-        '<table width="100%"><tr>'
-        '<td style="font-size:12px;color:#777777;">Project</td>'
-        f'<td align="right" style="font-size:12px;color:#111111;font-weight:500;">{project_name}</td>'
-        '</tr></table></td></tr>'
-
-        '<tr><td style="padding:10px 16px;border-bottom:0.5px solid #e2e2e6;">'
-        '<table width="100%"><tr>'
-        '<td style="font-size:12px;color:#777777;">Status</td>'
-        f'<td align="right"><span style="font-size:11px;font-weight:500;padding:3px 10px;border-radius:6px;{badge_style}">{status_label}</span></td>'
-        '</tr></table></td></tr>'
-
-        '<tr><td style="padding:10px 16px;">'
-        '<table width="100%"><tr>'
-        f'<td style="font-size:12px;color:#777777;">{time_label}</td>'
-        f'<td align="right" style="font-size:12px;color:#111111;">{timestamp}</td>'
-        '</tr></table></td></tr>'
-
-        '</table>'
-
-        f'{extra_block}'
-        f'{cta_block}'
-
-        f'<p style="margin:0;font-size:12px;color:#999999;line-height:1.6;">{footnote}</p>'
-        '</td></tr>'
-
-        '<tr><td style="border-top:0.5px solid #e2e2e6;padding:12px 32px;background:#f8f8fa;">'
-        '<table width="100%"><tr>'
-        '<td style="font-size:11px;color:#999999;">Rejuve Biotech · Hypothesis Generation</td>'
-        '<td align="right" style="font-size:11px;color:#999999;">© 2026</td>'
-        '</tr></table></td></tr>'
-
-        '</table></td></tr></table></body></html>'
-    )
-
-
-def _cta(url: str, label: str) -> str:
-    return (
-        f'<a href="{url}" style="display:inline-block;background:#5a4fcf;color:#ffffff;'
-        'text-decoration:none;padding:10px 22px;border-radius:8px;'
-        f'font-size:13px;font-weight:500;margin-bottom:20px;">{label}</a>'
-    )
-
-
-def _message_block(message: str) -> str:
-    return (
-        '<table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:20px;">'
-        '<tr><td style="border-left:3px solid #e24b4a;padding:14px 18px;background:#fff8f8;border-radius:0 6px 6px 0;">'
-        '<p style="margin:0 0 4px;font-size:11px;font-weight:600;color:#a32d2d;'
-        'text-transform:uppercase;letter-spacing:0.08em;">What went wrong</p>'
-        f'<p style="margin:0;font-size:13px;color:#333333;line-height:1.65;">{message}</p>'
-        '</td></tr></table>'
-    )
+_ICON_FAILED = (
+    f'<img src="{_BASE_URL}/dna-failed.png" '
+    'width="160" height="160" alt="" '
+    'style="display:block;margin:0 auto;" />'
+)
 
 
 def _get_user_friendly_error(raw: str | None) -> str:
@@ -164,36 +84,53 @@ def build_complete_email(
     result_url = f"{app_base_url.rstrip('/')}/hypothesis/{project_id}"
     ts = _now_utc()
 
-    html = _build_html(
-        headline="Analysis complete",
-        top_bar_color="#5a4fcf",
-        first_name=first_name,
-        intro=(
-            f"Your analysis for project <strong style='font-weight:500;color:#111111;'>"
-            f"{project_name}</strong> has finished running successfully. "
-            "Your results are ready to review."
-        ),
-        project_name=project_name,
-        badge_style="background:#eaf3de;color:#3b6d11;",
-        status_label="Completed",
-        time_label="Finished at",
-        timestamp=ts,
-        extra_block="",
-        cta_block=_cta(result_url, "View results →"),
-        footnote=(
-            "You're receiving this because you triggered an analysis run on the "
-            "Hypothesis Generation platform. If you didn't expect this, you can ignore it."
-        ),
+    html = (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1"></head>'
+        '<body style="margin:0;padding:0;background:#ffffff;'
+        'font-family:Inter,-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">'
+
+        '<table width="100%" cellpadding="0" cellspacing="0" style="background:#ffffff;padding:48px 24px;">'
+        '<tr><td align="center">'
+        '<table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;width:100%;text-align:center;">'
+
+        '<tr><td align="center" style="padding-bottom:32px;">'
+        + _ICON_SUCCESS +
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:16px;">'
+        '<h1 style="margin:0;font-size:32px;font-weight:800;color:#4a4a4a;letter-spacing:-0.02em;">Analysis Complete</h1>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:12px;">'
+        f'<p style="margin:0 auto;font-size:20px;line-height:1.45;color:#818181;max-width:540px;">'
+        f'Your analysis for project <strong style="color:#4a4a4a;font-weight:600;">{project_name}</strong> '
+        'has finished running successfully. Your results are ready to view.</p>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:32px;">'
+        f'<p style="margin:0;font-size:14px;font-weight:600;color:#a1a1a1;">Finished at {ts}</p>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:48px;">'
+        f'<a href="{result_url}" style="display:inline-block;background:#151515;color:#ffffff;'
+        'text-decoration:none;padding:15px 28px;border-radius:8px;'
+        'font-size:18px;font-weight:700;">View Result →</a>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="border-top:1px solid #f0f0f0;padding-top:24px;">'
+        '<p style="margin:0;font-size:12px;color:#cccccc;">Rejuve Biotech · Hypothesis Generation Platform</p>'
+        '</td></tr>'
+
+        '</table></td></tr></table>'
+        '</body></html>'
     )
 
     plain = (
-        f"REJUVE BIOTECH — Analysis complete\n"
+        f"REJUVE BIOTECH — Analysis Complete\n"
         f"{'─' * 40}\n\n"
-        f"Hi {first_name},\n\n"
         f"Your analysis for '{project_name}' completed successfully.\n\n"
-        f"Project : {project_name}\n"
-        f"Status  : Completed\n"
-        f"Time    : {ts}\n\n"
+        f"Finished at : {ts}\n"
         f"View results: {result_url}\n\n"
         "Rejuve Biotech · Hypothesis Generation Platform"
     )
@@ -215,33 +152,57 @@ def build_failed_email(
     ts = _now_utc()
     friendly = _get_user_friendly_error(error)
 
-    html = _build_html(
-        headline="Analysis failed",
-        top_bar_color="#e24b4a",
-        first_name=first_name,
-        intro=(
-            f"Unfortunately the analysis for project <strong style='font-weight:500;color:#111111;'>"
-            f"{project_name}</strong> did not complete successfully."
-        ),
-        project_name=project_name,
-        badge_style="background:#fcebeb;color:#a32d2d;",
-        status_label="Failed",
-        time_label="Failed at",
-        timestamp=ts,
-        extra_block=_message_block(friendly),
-        cta_block="",
-        footnote="Please retry the analysis or contact your administrator if the issue persists.",
+    html = (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1"></head>'
+        '<body style="margin:0;padding:0;background:#ffffff;'
+        'font-family:Inter,-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">'
+
+        '<table width="100%" cellpadding="0" cellspacing="0" style="background:#ffffff;padding:48px 24px;">'
+        '<tr><td align="center">'
+        '<table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;width:100%;text-align:center;">'
+
+        '<tr><td align="center" style="padding-bottom:32px;">'
+        + _ICON_FAILED +
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:16px;">'
+        '<h1 style="margin:0;font-size:32px;font-weight:800;color:#4a4a4a;letter-spacing:-0.02em;">Analysis failed</h1>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:12px;">'
+        f'<p style="margin:0 auto;font-size:20px;line-height:1.45;color:#818181;max-width:540px;">'
+        f'Unfortunately your analysis for project <strong style="color:#4a4a4a;font-weight:600;">{project_name}</strong> '
+        'did not complete successfully.</p>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="padding-bottom:32px;">'
+        f'<p style="margin:0;font-size:14px;font-weight:600;color:#a1a1a1;">Failed at {ts}</p>'
+        '</td></tr>'
+
+        '<tr><td align="left" style="padding-bottom:40px;">'
+        '<table width="100%" cellpadding="0" cellspacing="0" '
+        'style="background:#fef2f2;border:1px solid #fecaca;border-radius:12px;">'
+        '<tr><td style="padding:20px 22px;text-align:left;">'
+        '<p style="margin:0 0 8px;font-size:16px;font-weight:800;color:#991b1b;">What went wrong</p>'
+        f'<p style="margin:0;font-size:15px;line-height:1.55;color:#7f1d1d;">{friendly}</p>'
+        '</td></tr></table>'
+        '</td></tr>'
+
+        '<tr><td align="center" style="border-top:1px solid #f0f0f0;padding-top:24px;">'
+        '<p style="margin:0;font-size:12px;color:#cccccc;">Rejuve Biotech · Hypothesis Generation Platform</p>'
+        '</td></tr>'
+
+        '</table></td></tr></table>'
+        '</body></html>'
     )
 
     plain = (
         f"REJUVE BIOTECH — Analysis failed\n"
         f"{'─' * 40}\n\n"
-        f"Hi {first_name},\n\n"
         f"The analysis for project '{project_name}' did not complete.\n\n"
-        f"Project : {project_name}\n"
-        f"Status  : Failed\n"
-        f"Time    : {ts}\n"
-        f"Details : {friendly}\n\n"
+        f"Failed at : {ts}\n"
+        f"Details   : {friendly}\n\n"
         "Please retry or contact your administrator.\n\n"
         "Rejuve Biotech · Hypothesis Generation Platform"
     )


### PR DESCRIPTION
## Summary
Users now receive an email when their analysis completes or fails. They can kick off a run and come back when it's done instead of staying on the platform waiting for updates.

## What changed

**Email service (`src/services/mail/`)**
Organised as a package:
- `client.py` — FastMail setup and `send_email`
- `templates.py` — Rejuve-branded HTML + plain-text templates, light theme, renders correctly across clients including Gmail dark mode
- `notifications.py` — `send_pipeline_notification`, the single entry point called by the pipeline
- `__init__.py` — re-exports for clean imports

**Analysis pipeline (`src/flows/analysis.py`)**
- Success email sent at 100% completion with a direct link to results
- Failure email sent at every failure point — COJO, fine-mapping, LDSC, and unexpected exceptions
- Raw backend errors and tracebacks are never exposed to the user; messages are mapped per pipeline stage

**Auth & routing (`src/api/auth.py`, `src/api/routes/projects.py`)**
- Added `get_current_user_email` dependency to extract the `email` claim from the Bearer JWT
- `POST /analysis-pipeline` passes it through to the Prefect flow and persists it on the project record

## Notes
- Email is fully optional — if `MAIL_SERVER` is not set the pipeline continues normally
- Email failure never affects pipeline state
- Tokens without an `email` claim silently skip the notification — no auth service changes required

## Screenshots
<img width="842" height="677" alt="image" src="https://github.com/user-attachments/assets/3d83588f-66ed-4f3b-a523-9eb187c7c405" />


<img width="782" height="648" alt="image" src="https://github.com/user-attachments/assets/a7d69531-5ba5-437f-8664-8ad216583691" />
