### PR TITLE
Skip SuSiE fine-mapping when Open Targets already has a credible set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,6 @@ work/
 
 
 CLAUDE.md
+
+
+/data/ot_uc_sumstats

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -192,13 +192,14 @@ services:
     networks:
       - app_network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${CREDIBLE_SETS_DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${CREDIBLE_SETS_DB_USER} -d ${CREDIBLE_SETS_DB_NAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
 
   credible-sets-loader:
+    profiles: ["tools"]
     build:
       context: ..
       dockerfile: docker/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -191,6 +191,28 @@ services:
       retries: 5
     restart: unless-stopped
 
+  credible-sets-loader:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      - CREDIBLE_SETS_DB_HOST=credible-sets-postgres
+      - CREDIBLE_SETS_DB_PORT=5432
+      - CREDIBLE_SETS_DB_NAME=${CREDIBLE_SETS_DB_NAME}
+      - CREDIBLE_SETS_DB_USER=${CREDIBLE_SETS_DB_USER}
+      - CREDIBLE_SETS_DB_PASSWORD=${CREDIBLE_SETS_DB_PASSWORD}
+      - PYTHONPATH=/app
+    volumes:
+      - ..:/app
+    depends_on:
+      credible-sets-postgres:
+        condition: service_healthy
+    command: >
+      uv run python scripts/load_credible_sets_to_postgres.py --release latest
+    networks:
+      - app_network
+    restart: "no"
+
   prefect-service:
     build:
       context: ..

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -211,6 +211,7 @@ services:
       - PYTHONPATH=/app
     volumes:
       - ..:/app
+    entrypoint: []
     depends_on:
       credible-sets-postgres:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - "5411:5432"
     volumes:
       - credible-sets-postgres-data:/var/lib/postgresql/data
+      - ./init-credible-sets.sql:/docker-entrypoint-initdb.d/init.sql:ro
     networks:
       - app_network
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -171,6 +171,25 @@ services:
       retries: 5
     restart: unless-stopped
 
+  credible-sets-postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: ${CREDIBLE_SETS_DB_USER}
+      POSTGRES_PASSWORD: ${CREDIBLE_SETS_DB_PASSWORD}
+      POSTGRES_DB: ${CREDIBLE_SETS_DB_NAME}
+    ports:
+      - "5411:5432"
+    volumes:
+      - credible-sets-postgres-data:/var/lib/postgresql/data
+    networks:
+      - app_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${CREDIBLE_SETS_DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
   prefect-service:
     build:
       context: ..
@@ -275,6 +294,7 @@ volumes:
   mongo-data:
   prefect-data:
   prefect-postgres-data:
+  credible-sets-postgres-data:
 
 networks:
   app_network:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     volumes:
       - ..:/app
       - ../data:/app/data
-      - /mnt/hdd_1/rediet/hypothesis-generation-demo/data:/app/data/external_data
+      - ${EXTERNAL_DATA_PATH}:/app/data/external_data
     depends_on:
       dask-scheduler:
         condition: service_healthy
@@ -265,7 +265,7 @@ services:
     volumes:
       - ..:/app
       - ../data:/app/data
-      - /mnt/hdd_1/rediet/hypothesis-generation-demo/data:/app/data/external_data
+      - ${EXTERNAL_DATA_PATH}:/app/data/external_data
     env_file:
       - ../.env
     command: >

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - "4242:4242"
     volumes:
       - ../pl:/app/pl
-      - /mnt/hdd_1/biocypher-kg/output/human/prolog_out_v2:/mnt/prolog_out_v2
-      - /mnt/hdd_1/biocypher-kg/output/human/prolog_out_v3:/mnt/prolog_out_v3
+      - ${PROLOG_OUT_V2_PATH}:/mnt/prolog_out_v2
+      - ${PROLOG_OUT_V3_PATH}:/mnt/prolog_out_v3
     networks:
       - app_network
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       - SKIP_SEED=true
       - REDIS_URL=redis://redis:6379
       - OPENAI_API_KEY=${OpenAI}
+      - CREDIBLE_SETS_DB_HOST=credible-sets-postgres
+      - CREDIBLE_SETS_DB_PORT=5432
+      - CREDIBLE_SETS_DB_NAME=${CREDIBLE_SETS_DB_NAME}
+      - CREDIBLE_SETS_DB_USER=${CREDIBLE_SETS_DB_USER}
+      - CREDIBLE_SETS_DB_PASSWORD=${CREDIBLE_SETS_DB_PASSWORD}
     env_file:
       - ../.env
     volumes:
@@ -82,15 +87,17 @@ services:
       - /mnt/hdd_1/rediet/hypothesis-generation-demo/data:/app/data/external_data
     depends_on:
       dask-scheduler:
-        condition: service_healthy  
+        condition: service_healthy
       mongo:
         condition: service_healthy
       prolog-service:
         condition: service_started
       redis:
         condition: service_healthy
+      credible-sets-postgres:
+        condition: service_healthy
     command: >
-      uv run dask worker tcp://dask-scheduler:8786 
+      uv run dask worker tcp://dask-scheduler:8786
       --nworkers 4
       --nthreads 1 
       --memory-limit 40GB
@@ -288,6 +295,11 @@ services:
       - GO_MAP=/app/data/go_map.pkl
       - REDIS_URL=redis://redis:6379
       - OPENAI_API_KEY=${OpenAI}
+      - CREDIBLE_SETS_DB_HOST=credible-sets-postgres
+      - CREDIBLE_SETS_DB_PORT=5432
+      - CREDIBLE_SETS_DB_NAME=${CREDIBLE_SETS_DB_NAME}
+      - CREDIBLE_SETS_DB_USER=${CREDIBLE_SETS_DB_USER}
+      - CREDIBLE_SETS_DB_PASSWORD=${CREDIBLE_SETS_DB_PASSWORD}
     depends_on:
       prefect-service:
         condition: service_healthy
@@ -297,9 +309,11 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      credible-sets-postgres:
+        condition: service_healthy
     networks:
       - app_network
-  
+
   redis:
     image: redis:7-alpine
     ports:

--- a/docker/init-credible-sets.sql
+++ b/docker/init-credible-sets.sql
@@ -1,0 +1,47 @@
+-- Initialisation script for credible-sets-postgres.
+-- Runs automatically on first container startup (empty data volume).
+-- Subsequent starts skip this file.
+
+CREATE TABLE IF NOT EXISTS credible_sets (
+    study_locus_id          TEXT PRIMARY KEY,
+    study_id                TEXT NOT NULL,
+    variant_id              TEXT NOT NULL,
+    chromosome              TEXT,
+    position                INTEGER,
+    region                  TEXT,
+    beta                    DOUBLE PRECISION,
+    z_score                 DOUBLE PRECISION,
+    p_value_mantissa        REAL,
+    p_value_exponent        INTEGER,
+    effect_allele_frequency REAL,
+    standard_error          DOUBLE PRECISION,
+    sub_study_description   TEXT,
+    quality_controls        TEXT[],
+    finemap_method          TEXT,
+    credible_set_index      INTEGER,
+    credible_set_log10bf    DOUBLE PRECISION,
+    purity_mean_r2          DOUBLE PRECISION,
+    purity_min_r2           DOUBLE PRECISION,
+    locus_start             INTEGER,
+    locus_end               INTEGER,
+    sample_size             INTEGER,
+    ld_set                  JSONB,
+    locus                   JSONB,
+    confidence              TEXT,
+    study_type              TEXT,
+    is_trans_qtl            BOOLEAN
+);
+
+CREATE INDEX IF NOT EXISTS idx_cs_study_id   ON credible_sets(study_id);
+CREATE INDEX IF NOT EXISTS idx_cs_variant_id ON credible_sets(variant_id);
+CREATE INDEX IF NOT EXISTS idx_cs_chr_pos    ON credible_sets(chromosome, position);
+CREATE INDEX IF NOT EXISTS idx_cs_study_type ON credible_sets(study_type);
+CREATE INDEX IF NOT EXISTS idx_cs_region     ON credible_sets(region);
+
+-- Lightweight study-level summary used for fast "has credible sets?" checks.
+CREATE TABLE IF NOT EXISTS gwas_study_index (
+    study_id            TEXT PRIMARY KEY,
+    credible_set_count  INTEGER NOT NULL,
+    chromosomes         TEXT[],
+    finemap_methods     TEXT[]
+);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "statsmodels>=0.14.0",
     "dependency-injector>=4.41",
     "fastapi-mail>=1.4.0",
+    "psycopg2-binary>=2.9.9",
 ]
 
 [project.optional-dependencies]

--- a/scripts/fetch_opentargets_sumstats.py
+++ b/scripts/fetch_opentargets_sumstats.py
@@ -1,0 +1,551 @@
+"""
+Fetch GWAS summary statistics from Open Targets Platform for studies matching a trait.
+
+Workflow for each study:
+  1. Check if harmonized output already exists locally or in MinIO — skip if found.
+  2. Download raw summary stats from summarystatsLocation (gs:// or https://).
+  3. Inspect columns: if already in GWAS SSF format (Open Targets pre-harmonizes),
+     mark as ready and skip the Nextflow harmonization pipeline.
+  4. Otherwise flag the raw file as needing harmonization.
+
+Requirements:
+    pip install google-cloud-bigquery google-auth requests tqdm pandas
+
+    For GCS-hosted files (gs:// URLs):
+        Install the gcloud SDK so `gsutil` is on PATH, OR:
+        pip install google-cloud-storage
+
+Usage — via BigQuery (requires GCP credentials):
+    python scripts/fetch_opentargets_sumstats.py \\
+        --trait "ulcerative colitis" \\
+        --output-dir data/ot_uc_sumstats \\
+        --gcp-project my-gcp-project
+
+Usage — via GWAS Catalog REST API (no credentials needed, same underlying data):
+    python scripts/fetch_opentargets_sumstats.py \\
+        --trait "ulcerative colitis" \\
+        --source gwas-catalog \\
+        --output-dir data/ot_uc_sumstats
+
+Usage — from a pre-fetched CSV (columns: studyId, summarystatsLocation):
+    python scripts/fetch_opentargets_sumstats.py \\
+        --studies-csv studies.csv \\
+        --output-dir data/ot_uc_sumstats
+
+Results written to {output_dir}/manifest.csv with columns:
+    studyId, summarystatsLocation, status, local_path, needs_harmonization
+"""
+
+import argparse
+import gzip
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+from loguru import logger
+
+# GWAS SSF standard column names emitted by Open Targets / EMBL-EBI harmonisation
+_SSF_REQUIRED_COLS = {
+    "chromosome",
+    "base_pair_location",
+    "effect_allele",
+    "other_allele",
+    "beta",
+    "standard_error",
+    "p_value",
+}
+
+# MinIO object-key prefix for Open Targets harmonised files
+_MINIO_PREFIX = "harmonized/opentargets"
+
+
+# ---------------------------------------------------------------------------
+# BigQuery helpers
+# ---------------------------------------------------------------------------
+
+def _bq_query(trait: str, gcp_project: str) -> pd.DataFrame:
+    """Run the Open Targets study query against BigQuery and return a DataFrame."""
+    try:
+        from google.cloud import bigquery  # type: ignore
+    except ImportError:
+        logger.error(
+            "google-cloud-bigquery is not installed. "
+            "Run: pip install google-cloud-bigquery google-auth"
+        )
+        sys.exit(1)
+
+    sql = """
+        SELECT s.studyId, s.summarystatsLocation
+        FROM `open-targets-prod.platform.studies` s
+        WHERE LOWER(s.traitFromSource) LIKE @trait_pattern
+          AND s.studyType = 'gwas'
+          AND s.summarystatsLocation IS NOT NULL
+    """
+    client = bigquery.Client(project=gcp_project)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter(
+                "trait_pattern", "STRING", f"%{trait.lower()}%"
+            )
+        ]
+    )
+    logger.info(f"[BQ] Querying Open Targets for trait matching '{trait}' ...")
+    result = client.query(sql, job_config=job_config).to_dataframe()
+    logger.info(f"[BQ] Found {len(result)} studies with summary stats.")
+    return result
+
+
+def _gwas_catalog_query(trait: str, max_results: int = 50) -> pd.DataFrame:
+    """
+    Query the GWAS Catalog REST API for studies matching *trait* that have
+    summary statistics available.  Returns the same (studyId, summarystatsLocation)
+    schema as the BigQuery path, so the rest of the pipeline is identical.
+
+    The GWAS Catalog is the primary data source for Open Targets GWAS studies;
+    the `summarystatsLocation` column in Open Targets BigQuery is derived from
+    the same FTP paths returned here.
+    """
+    base = "https://www.ebi.ac.uk/gwas/rest/api"
+    page, page_size = 0, 100
+    all_studies: list[dict] = []
+
+    logger.info(f"[GWAS-Catalog] Searching for studies matching '{trait}' …")
+    while True:
+        params = {
+            "efoTrait": trait,
+            "page": page,
+            "size": page_size,
+        }
+        resp = requests.get(
+            f"{base}/studies/search/findByEfoTrait",
+            params=params,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        embedded = data.get("_embedded", {}).get("studies", [])
+        if not embedded:
+            break
+
+        all_studies.extend(embedded)
+        logger.info(f"[GWAS-Catalog] Fetched page {page}: {len(embedded)} studies (total so far: {len(all_studies)})")
+
+        page_info = data.get("page", {})
+        total_pages = page_info.get("totalPages", 1)
+        if page >= total_pages - 1:
+            break
+        page += 1
+
+    logger.info(f"[GWAS-Catalog] Total studies found: {len(all_studies)}")
+
+    rows: list[dict] = []
+    for s in all_studies:
+        if not s.get("fullPvalueSet", False):
+            continue  # no summary stats available
+        accession: str = s.get("accessionId", "")
+        if not accession:
+            continue
+
+        # Build the canonical EBI FTP HTTPS URL for this study's harmonised folder.
+        # Open Targets `summarystatsLocation` resolves to exactly this location.
+        bucket_start = (int(accession.replace("GCST", "")) // 1000) * 1000 + 1
+        bucket_end   = bucket_start + 999
+        ftp_dir = (
+            f"https://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics/"
+            f"GCST{bucket_start:06d}-GCST{bucket_end:06d}/{accession}/harmonised/"
+        )
+        rows.append({"studyId": accession, "summarystatsLocation": ftp_dir})
+        if len(rows) >= max_results:
+            break
+
+    df = pd.DataFrame(rows, columns=["studyId", "summarystatsLocation"])
+    logger.info(f"[GWAS-Catalog] {len(df)} studies with summary statistics.")
+    return df
+
+
+def _load_studies_csv(csv_path: str) -> pd.DataFrame:
+    df = pd.read_csv(csv_path)
+    required = {"studyId", "summarystatsLocation"}
+    missing = required - set(df.columns)
+    if missing:
+        logger.error(f"CSV is missing required columns: {missing}")
+        sys.exit(1)
+    return df[["studyId", "summarystatsLocation"]].dropna()
+
+
+# ---------------------------------------------------------------------------
+# Existence checks
+# ---------------------------------------------------------------------------
+
+def _harmonized_local_path(output_dir: str, study_id: str) -> str:
+    return os.path.join(output_dir, f"{study_id}_harmonized.tsv.gz")
+
+
+def _raw_local_path(output_dir: str, study_id: str, url: str) -> str:
+    ext = _url_extension(url)
+    return os.path.join(output_dir, f"{study_id}_raw{ext}")
+
+
+def _url_extension(url: str) -> str:
+    """Best-effort file extension from a URL."""
+    name = url.rstrip("/").split("/")[-1].split("?")[0]
+    for ext in (".tsv.gz", ".vcf.gz", ".tsv", ".vcf", ".gz", ".parquet"):
+        if name.endswith(ext):
+            return ext
+    return ".tsv.gz"
+
+
+def _check_minio(study_id: str) -> Optional[str]:
+    """Return MinIO object key if the harmonised file exists, else None."""
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        from src.services.storage import create_minio_client_from_env
+
+        storage = create_minio_client_from_env()
+        if storage is None:
+            return None
+        key = f"{_MINIO_PREFIX}/{study_id}_harmonized.tsv.gz"
+        if storage.exists(key):
+            return key
+    except Exception as exc:
+        logger.debug(f"[MinIO] Check skipped ({exc})")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Download helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_directory_url(dir_url: str) -> Optional[str]:
+    """
+    If *dir_url* is an HTTPS directory listing (ends with /), find the best
+    summary-stats file inside it by parsing the HTML index.
+
+    Preference order:
+      1. *.h.tsv.gz  — EMBL-EBI harmonised (already in SSF format, no re-harmonisation needed)
+      2. *.tsv.gz    — any other gzip TSV
+      3. *.vcf.gz    — VCF fallback
+
+    Returns the resolved absolute file URL, or None if nothing suitable is found.
+    """
+    try:
+        import re
+
+        resp = requests.get(dir_url, timeout=20)
+        resp.raise_for_status()
+        candidates = re.findall(r'href="([^"]+)"', resp.text)
+
+        def _abs(name: str) -> str:
+            return name if name.startswith("http") else dir_url.rstrip("/") + "/" + name.lstrip("/")
+
+        # Prefer harmonised files first
+        for name in candidates:
+            if name.endswith(".h.tsv.gz"):
+                return _abs(name)
+        for name in candidates:
+            if name.endswith(".tsv.gz"):
+                return _abs(name)
+        for name in candidates:
+            if name.endswith(".vcf.gz"):
+                return _abs(name)
+    except Exception as exc:
+        logger.warning(f"[DOWNLOAD] Could not resolve directory URL {dir_url}: {exc}")
+    return None
+
+
+def _download_https(url: str, dest_path: str) -> None:
+    # If url is a directory, resolve to the actual file first
+    if url.endswith("/"):
+        resolved = _resolve_directory_url(url)
+        if not resolved:
+            raise RuntimeError(
+                f"Could not find a .tsv.gz/.vcf.gz file in directory: {url}"
+            )
+        logger.info(f"[DOWNLOAD] Resolved directory → {resolved}")
+        url = resolved
+
+    logger.info(f"[DOWNLOAD] HTTP → {dest_path}")
+    with requests.get(url, stream=True, timeout=600) as r:
+        r.raise_for_status()
+        with open(dest_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=65536):
+                f.write(chunk)
+    logger.info(f"[DOWNLOAD] Done ({os.path.getsize(dest_path) / 1e6:.1f} MB)")
+
+
+def _download_gcs(gcs_url: str, dest_path: str) -> None:
+    """Download a gs:// URL using gsutil (preferred) or google-cloud-storage."""
+    # Try gsutil first (simplest, honours application-default credentials)
+    try:
+        result = subprocess.run(
+            ["gsutil", "cp", gcs_url, dest_path],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if result.returncode == 0:
+            logger.info(f"[DOWNLOAD] gsutil OK → {dest_path}")
+            return
+        logger.warning(f"[DOWNLOAD] gsutil failed: {result.stderr.strip()}")
+    except FileNotFoundError:
+        logger.warning("[DOWNLOAD] gsutil not found, trying google-cloud-storage SDK …")
+
+    # Fall back to the Python SDK
+    try:
+        from google.cloud import storage as gcs  # type: ignore
+
+        # gs://bucket/blob
+        without_prefix = gcs_url[len("gs://"):]
+        bucket_name, _, blob_name = without_prefix.partition("/")
+        client = gcs.Client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        blob.download_to_filename(dest_path)
+        logger.info(f"[DOWNLOAD] GCS SDK OK → {dest_path}")
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot download {gcs_url}: gsutil unavailable and google-cloud-storage failed ({exc}). "
+            "Install the gcloud SDK or: pip install google-cloud-storage"
+        ) from exc
+
+
+def _download(url: str, dest_path: str) -> None:
+    if url.startswith("gs://"):
+        _download_gcs(url, dest_path)
+    elif url.startswith(("http://", "https://")):
+        _download_https(url, dest_path)
+    else:
+        raise ValueError(f"Unsupported URL scheme: {url}")
+
+
+# ---------------------------------------------------------------------------
+# SSF format detection
+# ---------------------------------------------------------------------------
+
+def _is_ssf_format(file_path: str) -> bool:
+    """
+    Return True if the file already contains GWAS SSF standard columns.
+    Reads only the header line so this is fast even for large files.
+    """
+    try:
+        opener = gzip.open if file_path.endswith(".gz") else open
+        with opener(file_path, "rt", encoding="utf-8", errors="replace") as fh:
+            header_line = fh.readline().rstrip("\n")
+        cols = {c.strip().lower() for c in header_line.split("\t")}
+        found = _SSF_REQUIRED_COLS & cols
+        logger.debug(f"[SSF] {file_path}: matched {len(found)}/{len(_SSF_REQUIRED_COLS)} required cols")
+        return len(found) == len(_SSF_REQUIRED_COLS)
+    except Exception as exc:
+        logger.warning(f"[SSF] Could not inspect {file_path}: {exc}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main processing loop
+# ---------------------------------------------------------------------------
+
+def process_studies(studies: pd.DataFrame, output_dir: str) -> pd.DataFrame:
+    """
+    For each study:
+      - skip if harmonized output already exists
+      - download raw file
+      - detect if already in SSF format
+      - report status
+
+    Returns a manifest DataFrame.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    records = []
+
+    for _, row in studies.iterrows():
+        study_id: str = str(row["studyId"]).strip()
+        sumstats_loc: str = str(row["summarystatsLocation"]).strip()
+
+        record: dict = {
+            "studyId": study_id,
+            "summarystatsLocation": sumstats_loc,
+            "status": None,
+            "local_path": None,
+            "needs_harmonization": False,
+            "minio_key": None,
+        }
+
+        logger.info(f"[{study_id}] Processing …")
+
+        # ── 1. Check for existing harmonized output ──────────────────────────
+        harmonized_path = _harmonized_local_path(output_dir, study_id)
+        if os.path.exists(harmonized_path):
+            logger.info(f"[{study_id}] Harmonized file exists locally → skipping.")
+            record.update(
+                status="already_harmonized",
+                local_path=harmonized_path,
+                needs_harmonization=False,
+            )
+            records.append(record)
+            continue
+
+        minio_key = _check_minio(study_id)
+        if minio_key:
+            logger.info(f"[{study_id}] Harmonized file found in MinIO ({minio_key}) → skipping.")
+            record.update(
+                status="already_harmonized_minio",
+                minio_key=minio_key,
+                needs_harmonization=False,
+            )
+            records.append(record)
+            continue
+
+        # ── 2. Check for already-downloaded raw file ──────────────────────────
+        raw_path = _raw_local_path(output_dir, study_id, sumstats_loc)
+        if os.path.exists(raw_path):
+            logger.info(f"[{study_id}] Raw file already present at {raw_path} → skipping download.")
+        else:
+            # ── 3. Download ──────────────────────────────────────────────────
+            try:
+                _download(sumstats_loc, raw_path)
+            except Exception as exc:
+                logger.error(f"[{study_id}] Download failed: {exc}")
+                record.update(status="download_failed")
+                records.append(record)
+                continue
+
+        # ── 4. Detect if already in SSF format ────────────────────────────────
+        already_harmonized = _is_ssf_format(raw_path)
+
+        if already_harmonized:
+            # Rename to the harmonized path so downstream code finds it
+            os.rename(raw_path, harmonized_path)
+            logger.info(
+                f"[{study_id}] File is already in SSF format → "
+                f"renamed to {harmonized_path}, harmonization skipped."
+            )
+            record.update(
+                status="ssf_ready",
+                local_path=harmonized_path,
+                needs_harmonization=False,
+            )
+        else:
+            logger.info(
+                f"[{study_id}] File is NOT in SSF format → "
+                f"needs Nextflow harmonization."
+            )
+            record.update(
+                status="needs_harmonization",
+                local_path=raw_path,
+                needs_harmonization=True,
+            )
+
+        records.append(record)
+
+    manifest = pd.DataFrame(records)
+    manifest_path = os.path.join(output_dir, "manifest.csv")
+    manifest.to_csv(manifest_path, index=False)
+    logger.info(f"\nManifest written to {manifest_path}")
+    _print_summary(manifest)
+    return manifest
+
+
+def _print_summary(manifest: pd.DataFrame) -> None:
+    counts = manifest["status"].value_counts()
+    logger.info("── Summary ──────────────────────────────────")
+    for status, n in counts.items():
+        logger.info(f"  {status:<35} {n}")
+    needs = manifest["needs_harmonization"].sum()
+    if needs:
+        logger.info(
+            f"\n{needs} file(s) still need Nextflow harmonization.\n"
+            "Pass the paths in the 'local_path' column to analysis_pipeline_flow()."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    source = p.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--trait",
+        help=(
+            'Trait name to search (e.g. "ulcerative colitis"). '
+            "Source depends on --source flag (default: bigquery)."
+        ),
+    )
+    source.add_argument(
+        "--studies-csv",
+        metavar="PATH",
+        help="CSV file with columns studyId and summarystatsLocation (skips API queries).",
+    )
+    p.add_argument(
+        "--source",
+        choices=["bigquery", "gwas-catalog"],
+        default="bigquery",
+        help=(
+            "Where to query study metadata. "
+            "'gwas-catalog' uses the public GWAS Catalog REST API (no GCP credentials needed). "
+            "'bigquery' uses Open Targets BigQuery (requires --gcp-project). "
+            "Default: bigquery."
+        ),
+    )
+    p.add_argument(
+        "--output-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory where downloaded / harmonized files will be stored.",
+    )
+    p.add_argument(
+        "--gcp-project",
+        metavar="PROJECT_ID",
+        help="Google Cloud project to bill BigQuery queries to (required with --source bigquery).",
+    )
+    p.add_argument(
+        "--max-studies",
+        type=int,
+        default=50,
+        metavar="N",
+        help="Maximum number of studies to process (default: 50).",
+    )
+    return p
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.studies_csv:
+        studies = _load_studies_csv(args.studies_csv)
+    elif args.source == "gwas-catalog":
+        studies = _gwas_catalog_query(args.trait, max_results=args.max_studies)
+    else:
+        if not args.gcp_project:
+            parser.error("--gcp-project is required when using --source bigquery.")
+        studies = _bq_query(args.trait, args.gcp_project)
+
+    if studies.empty:
+        logger.warning("No studies found. Nothing to do.")
+        sys.exit(0)
+
+    if args.max_studies and len(studies) > args.max_studies:
+        studies = studies.head(args.max_studies)
+
+    logger.info(f"Processing {len(studies)} studies → {args.output_dir}")
+    process_studies(studies, args.output_dir)
+
+
+if __name__ == "__main__":
+    _root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(_root))
+    main()

--- a/scripts/load_credible_sets_to_postgres.py
+++ b/scripts/load_credible_sets_to_postgres.py
@@ -273,6 +273,15 @@ def main():
     conn.commit()
     print("Schema created/verified.")
 
+    # Exit early if data is already fully loaded (avoid re-downloading on every restart)
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM gwas_study_index")
+        study_count = cur.fetchone()[0]
+    if study_count > 0 and not args.resume:
+        print(f"Data already loaded ({study_count:,} studies in gwas_study_index). Skipping.")
+        conn.close()
+        return
+
     if args.resume:
         n = already_loaded_count(conn)
         if n > 0:

--- a/scripts/load_credible_sets_to_postgres.py
+++ b/scripts/load_credible_sets_to_postgres.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Load OpenTargets credible sets (Parquet) into PostgreSQL.
+
+Schema fields come from:
+  https://ftp.ebi.ac.uk/pub/databases/opentargets/platform/latest/output/credible_set/
+
+Connection is configured via environment variables:
+  CREDIBLE_SETS_DB_HOST     (default: localhost)
+  CREDIBLE_SETS_DB_PORT     (default: 5411)
+  CREDIBLE_SETS_DB_NAME     (default: credible_sets)
+  CREDIBLE_SETS_DB_USER     (default: credsets)
+  CREDIBLE_SETS_DB_PASSWORD (required)
+
+Usage:
+  python scripts/load_credible_sets_to_postgres.py [--release 25.06] [--resume]
+"""
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import tempfile
+import time
+import urllib.request
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+import pyarrow.parquet as pq
+
+# ── configuration ────────────────────────────────────────────────────────────
+
+BASE_URL = "https://ftp.ebi.ac.uk/pub/databases/opentargets/platform"
+FOLDER = "credible_set"
+BATCH_SIZE = 5000
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS credible_sets (
+    study_locus_id          TEXT PRIMARY KEY,
+    study_id                TEXT NOT NULL,
+    variant_id              TEXT NOT NULL,
+    chromosome              TEXT,
+    position                INTEGER,
+    region                  TEXT,
+    beta                    DOUBLE PRECISION,
+    z_score                 DOUBLE PRECISION,
+    p_value_mantissa        REAL,
+    p_value_exponent        INTEGER,
+    effect_allele_frequency REAL,
+    standard_error          DOUBLE PRECISION,
+    sub_study_description   TEXT,
+    quality_controls        TEXT[],
+    finemap_method          TEXT,
+    credible_set_index      INTEGER,
+    credible_set_log10bf    DOUBLE PRECISION,
+    purity_mean_r2          DOUBLE PRECISION,
+    purity_min_r2           DOUBLE PRECISION,
+    locus_start             INTEGER,
+    locus_end               INTEGER,
+    sample_size             INTEGER,
+    ld_set                  JSONB,
+    locus                   JSONB,
+    confidence              TEXT,
+    study_type              TEXT,
+    is_trans_qtl            BOOLEAN
+);
+CREATE INDEX IF NOT EXISTS idx_cs_study_id    ON credible_sets(study_id);
+CREATE INDEX IF NOT EXISTS idx_cs_variant_id  ON credible_sets(variant_id);
+CREATE INDEX IF NOT EXISTS idx_cs_chr_pos     ON credible_sets(chromosome, position);
+CREATE INDEX IF NOT EXISTS idx_cs_study_type  ON credible_sets(study_type);
+CREATE INDEX IF NOT EXISTS idx_cs_region      ON credible_sets(region);
+
+CREATE TABLE IF NOT EXISTS gwas_study_index (
+    study_id            TEXT PRIMARY KEY,
+    credible_set_count  INTEGER NOT NULL,
+    chromosomes         TEXT[],
+    finemap_methods     TEXT[]
+);
+"""
+
+BUILD_STUDY_INDEX_SQL = """
+INSERT INTO gwas_study_index (study_id, credible_set_count, chromosomes, finemap_methods)
+SELECT
+    study_id,
+    COUNT(*)                                                    AS credible_set_count,
+    ARRAY_AGG(DISTINCT chromosome ORDER BY chromosome)          AS chromosomes,
+    ARRAY_AGG(DISTINCT finemap_method ORDER BY finemap_method)  AS finemap_methods
+FROM credible_sets
+GROUP BY study_id
+ON CONFLICT (study_id) DO UPDATE SET
+    credible_set_count = EXCLUDED.credible_set_count,
+    chromosomes        = EXCLUDED.chromosomes,
+    finemap_methods    = EXCLUDED.finemap_methods;
+"""
+
+INSERT_SQL = """
+INSERT INTO credible_sets (
+    study_locus_id, study_id, variant_id, chromosome, position,
+    region, beta, z_score, p_value_mantissa, p_value_exponent,
+    effect_allele_frequency, standard_error, sub_study_description,
+    quality_controls, finemap_method, credible_set_index,
+    credible_set_log10bf, purity_mean_r2, purity_min_r2,
+    locus_start, locus_end, sample_size, ld_set, locus,
+    confidence, study_type, is_trans_qtl
+) VALUES %s
+ON CONFLICT (study_locus_id) DO NOTHING
+"""
+
+
+# ── type helpers ─────────────────────────────────────────────────────────────
+
+def _float(v):
+    if v is None:
+        return None
+    if isinstance(v, (np.floating, float)):
+        return None if math.isnan(v) else float(v)
+    return float(v)
+
+
+def _int(v):
+    if v is None:
+        return None
+    if isinstance(v, (np.floating, float)):
+        return None if math.isnan(v) else int(v)
+    if isinstance(v, np.integer):
+        return int(v)
+    return int(v) if v is not None else None
+
+
+def _bool(v):
+    if v is None:
+        return None
+    if isinstance(v, (np.bool_,)):
+        return bool(v)
+    return v
+
+
+def _list(v):
+    if v is None:
+        return None
+    if isinstance(v, np.ndarray):
+        return v.tolist()
+    return list(v) if v is not None else None
+
+
+def _json(v):
+    if v is None:
+        return None
+    if isinstance(v, np.ndarray):
+        v = v.tolist()
+
+    def default(obj):
+        if isinstance(obj, (np.integer,)):
+            return int(obj)
+        if isinstance(obj, (np.floating,)):
+            return None if math.isnan(obj) else float(obj)
+        if isinstance(obj, np.bool_):
+            return bool(obj)
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return str(obj)
+
+    return json.dumps(v, default=default)
+
+
+def row_to_tuple(row: dict) -> tuple:
+    return (
+        row["studyLocusId"],
+        row["studyId"],
+        row["variantId"],
+        row.get("chromosome"),
+        _int(row.get("position")),
+        row.get("region"),
+        _float(row.get("beta")),
+        _float(row.get("zScore")),
+        _float(row.get("pValueMantissa")),
+        _int(row.get("pValueExponent")),
+        _float(row.get("effectAlleleFrequencyFromSource")),
+        _float(row.get("standardError")),
+        row.get("subStudyDescription"),
+        _list(row.get("qualityControls")),
+        row.get("finemappingMethod"),
+        _int(row.get("credibleSetIndex")),
+        _float(row.get("credibleSetlog10BF")),
+        _float(row.get("purityMeanR2")),
+        _float(row.get("purityMinR2")),
+        _int(row.get("locusStart")),
+        _int(row.get("locusEnd")),
+        _int(row.get("sampleSize")),
+        _json(row.get("ldSet")),
+        _json(row.get("locus")),
+        row.get("confidence"),
+        row.get("studyType"),
+        _bool(row.get("isTransQtl")),
+    )
+
+
+# ── database / FTP helpers ───────────────────────────────────────────────────
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.environ.get("CREDIBLE_SETS_DB_HOST", "localhost"),
+        port=int(os.environ.get("CREDIBLE_SETS_DB_PORT", "5411")),
+        dbname=os.environ.get("CREDIBLE_SETS_DB_NAME", "credible_sets"),
+        user=os.environ.get("CREDIBLE_SETS_DB_USER", "credsets"),
+        password=os.environ.get("CREDIBLE_SETS_DB_PASSWORD", ""),
+    )
+
+
+def list_parquet_urls(release: str) -> list:
+    url = f"{BASE_URL}/{release}/output/{FOLDER}/"
+    with urllib.request.urlopen(url) as resp:
+        html = resp.read().decode()
+    files = re.findall(r'href="([^"]+\.parquet)"', html)
+    if not files:
+        raise RuntimeError(f"No parquet files found at {url}")
+    return sorted(f"{BASE_URL}/{release}/output/{FOLDER}/{f}" for f in files)
+
+
+def already_loaded_count(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM credible_sets")
+        return cur.fetchone()[0]
+
+
+def process_file(conn, url: str, file_num: int, total: int) -> int:
+    fname = url.split("/")[-1]
+    print(f"  [{file_num}/{total}] {fname} ... ", end="", flush=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as tmp:
+        t0 = time.time()
+        urllib.request.urlretrieve(url, tmp.name)
+        table = pq.read_table(tmp.name)
+
+    df = table.to_pandas()
+    df = df[df["studyType"] == "gwas"]
+    records = [row_to_tuple(r) for r in df.to_dict("records")]
+
+    with conn.cursor() as cur:
+        psycopg2.extras.execute_values(cur, INSERT_SQL, records, page_size=BATCH_SIZE)
+    conn.commit()
+
+    print(f"{len(records):,} gwas rows  ({time.time()-t0:.1f}s)", flush=True)
+    return len(records)
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release",
+        default="latest",
+        help="OpenTargets release tag, e.g. '25.06' (default: latest)",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip files whose rows are already present (uses ON CONFLICT DO NOTHING)",
+    )
+    args = parser.parse_args()
+
+    print(f"\nOpenTargets credible sets → PostgreSQL  (release={args.release})\n")
+
+    conn = get_conn()
+    print(f"Connected to PostgreSQL.")
+
+    with conn.cursor() as cur:
+        cur.execute(CREATE_TABLE_SQL)
+    conn.commit()
+    print("Schema created/verified.")
+
+    if args.resume:
+        n = already_loaded_count(conn)
+        if n > 0:
+            print(f"Resuming: {n:,} rows already in table (duplicates skipped).")
+
+    urls = list_parquet_urls(args.release)
+    print(f"Found {len(urls)} parquet files.\n")
+
+    total_rows = 0
+    t_start = time.time()
+
+    for i, url in enumerate(urls, 1):
+        try:
+            total_rows += process_file(conn, url, i, len(urls))
+        except Exception as exc:
+            print(f"ERROR on {url}: {exc}", file=sys.stderr)
+            conn.rollback()
+
+    elapsed = time.time() - t_start
+    final_count = already_loaded_count(conn)
+
+    print(f"\nBuilding gwas_study_index ...", end=" ", flush=True)
+    with conn.cursor() as cur:
+        cur.execute(BUILD_STUDY_INDEX_SQL)
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM gwas_study_index")
+        study_count = cur.fetchone()[0]
+    print(f"{study_count:,} studies indexed.")
+
+    conn.close()
+
+    print(f"\n{'─'*60}")
+    print(f"Loaded {total_rows:,} gwas rows in {elapsed/60:.1f} min")
+    print(f"Total rows in credible_sets:  {final_count:,}")
+    print(f"Total rows in gwas_study_index: {study_count:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/load_credible_sets_to_postgres.py
+++ b/scripts/load_credible_sets_to_postgres.py
@@ -36,6 +36,17 @@ import pyarrow.parquet as pq
 BASE_URL = "https://ftp.ebi.ac.uk/pub/databases/opentargets/platform"
 FOLDER = "credible_set"
 BATCH_SIZE = 5000
+# Row-group read batch size for streaming a parquet file instead of loading it
+# whole into memory (a single file can be ~235MB, enough to OOM the loader).
+CHUNK_ROWS = 1_000
+# Rows vary wildly in size — some credible sets carry huge `locus`/`ld_set`
+# JSONB blobs (one file had a row group averaging ~27KB/row). Capping a
+# single execute_values() call by row count alone still let a ~135MB insert
+# through, which is what actually killed the Postgres connection. So each
+# insert is also capped by estimated serialized bytes.
+MAX_INSERT_BYTES = 8 * 1024 * 1024
+# Retries per chunk insert before giving up on that chunk and moving on.
+CHUNK_RETRIES = 2
 
 CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS credible_sets (
@@ -226,25 +237,82 @@ def already_loaded_count(conn) -> int:
         return cur.fetchone()[0]
 
 
-def process_file(conn, url: str, file_num: int, total: int) -> int:
+def insert_chunk_with_retry(conn, records: list):
+    """
+    Insert one chunk of rows, reconnecting and retrying if the connection
+    died server-side (e.g. OOM-killed) mid-insert. Returns the (possibly new)
+    connection object — callers must keep using the returned conn.
+    """
+    last_exc = None
+    for attempt in range(CHUNK_RETRIES + 1):
+        try:
+            with conn.cursor() as cur:
+                psycopg2.extras.execute_values(cur, INSERT_SQL, records, page_size=BATCH_SIZE)
+            conn.commit()
+            return conn
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+            last_exc = exc
+            print(f"    DB connection lost ({exc}); reconnecting (attempt {attempt + 1})", file=sys.stderr)
+            try:
+                conn.close()
+            except Exception:
+                pass
+            conn = get_conn()
+    raise last_exc
+
+
+def _estimate_row_bytes(record: tuple) -> int:
+    """Cheap size estimate dominated by the locus/ld_set JSONB text fields."""
+    size = 200  # fixed-width columns overhead
+    for v in record:
+        if isinstance(v, str):
+            size += len(v)
+    return size
+
+
+def process_file(conn, url: str, file_num: int, total: int):
+    """
+    Stream one parquet file in row-group-sized reads, then flush inserts in
+    byte-capped sub-batches (see MAX_INSERT_BYTES) so memory usage AND the
+    size of any single execute_values() call stay bounded, regardless of how
+    large individual rows are. Returns (conn, rows_inserted) — conn may be a
+    new connection object if a reconnect happened mid-file.
+    """
     fname = url.split("/")[-1]
     print(f"  [{file_num}/{total}] {fname} ... ", end="", flush=True)
 
+    inserted = 0
+    pending, pending_bytes = [], 0
+    t0 = time.time()
+
+    def flush():
+        nonlocal conn, inserted, pending, pending_bytes
+        if not pending:
+            return
+        conn = insert_chunk_with_retry(conn, pending)
+        inserted += len(pending)
+        pending, pending_bytes = [], 0
+
     with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as tmp:
-        t0 = time.time()
         urllib.request.urlretrieve(url, tmp.name)
-        table = pq.read_table(tmp.name)
+        parquet_file = pq.ParquetFile(tmp.name)
 
-    df = table.to_pandas()
-    df = df[df["studyType"] == "gwas"]
-    records = [row_to_tuple(r) for r in df.to_dict("records")]
+        for batch in parquet_file.iter_batches(batch_size=CHUNK_ROWS):
+            df = batch.to_pandas()
+            df = df[df["studyType"] == "gwas"]
+            if df.empty:
+                continue
+            for row in df.to_dict("records"):
+                record = row_to_tuple(row)
+                record_bytes = _estimate_row_bytes(record)
+                if pending and pending_bytes + record_bytes > MAX_INSERT_BYTES:
+                    flush()
+                pending.append(record)
+                pending_bytes += record_bytes
+        flush()
 
-    with conn.cursor() as cur:
-        psycopg2.extras.execute_values(cur, INSERT_SQL, records, page_size=BATCH_SIZE)
-    conn.commit()
-
-    print(f"{len(records):,} gwas rows  ({time.time()-t0:.1f}s)", flush=True)
-    return len(records)
+    print(f"{inserted:,} gwas rows  ({time.time()-t0:.1f}s)", flush=True)
+    return conn, inserted
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -295,10 +363,21 @@ def main():
 
     for i, url in enumerate(urls, 1):
         try:
-            total_rows += process_file(conn, url, i, len(urls))
+            conn, rows = process_file(conn, url, i, len(urls))
+            total_rows += rows
         except Exception as exc:
             print(f"ERROR on {url}: {exc}", file=sys.stderr)
-            conn.rollback()
+            try:
+                conn.rollback()
+            except Exception:
+                # Connection is dead beyond the retries already attempted in
+                # process_file — reconnect so the loop can continue to the
+                # remaining files instead of exiting.
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                conn = get_conn()
 
     elapsed = time.time() - t_start
     final_count = already_loaded_count(conn)

--- a/scripts/load_opentargets_studies.py
+++ b/scripts/load_opentargets_studies.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Load OpenTargets GWAS study metadata (Parquet) into PostgreSQL.
+
+This is the study-level index OpenTargets publishes separately from
+credible_set/ (see load_credible_sets_to_postgres.py). It carries fields the
+credible-sets dataset doesn't: projectId (authoritative source tag, e.g.
+"GCST" or "FINNGEN_R12"), traitFromSource / traitFromSourceMappedIds (EFO/MONDO
+ids), and summarystatsLocation (the raw sumstats file path). Use it to find
+which OpenTargets study, if any, corresponds to a trait a user is analyzing,
+independent of whether that study happens to already be in our own gwas_library.
+
+Schema fields come from:
+  https://ftp.ebi.ac.uk/pub/databases/opentargets/platform/latest/output/study/
+
+Connection is configured via environment variables:
+  CREDIBLE_SETS_DB_HOST     (default: localhost)
+  CREDIBLE_SETS_DB_PORT     (default: 5411)
+  CREDIBLE_SETS_DB_NAME     (default: credible_sets)
+  CREDIBLE_SETS_DB_USER     (default: credsets)
+  CREDIBLE_SETS_DB_PASSWORD (required)
+
+Usage:
+  python scripts/load_opentargets_studies.py [--release latest]
+"""
+
+import argparse
+import math
+import os
+import re
+import sys
+import tempfile
+import time
+import urllib.request
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+import pyarrow.parquet as pq
+
+BASE_URL = "https://ftp.ebi.ac.uk/pub/databases/opentargets/platform"
+FOLDER = "study"
+BATCH_SIZE = 5000
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS opentargets_studies (
+    study_id                TEXT PRIMARY KEY,
+    project_id              TEXT,
+    trait_from_source       TEXT,
+    trait_efo_ids           TEXT[],
+    has_sumstats            BOOLEAN,
+    summarystats_location   TEXT,
+    n_samples               INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_ots_project_id ON opentargets_studies(project_id);
+CREATE INDEX IF NOT EXISTS idx_ots_trait_efo  ON opentargets_studies USING GIN(trait_efo_ids);
+"""
+
+INSERT_SQL = """
+INSERT INTO opentargets_studies (
+    study_id, project_id, trait_from_source, trait_efo_ids,
+    has_sumstats, summarystats_location, n_samples
+) VALUES %s
+ON CONFLICT (study_id) DO UPDATE SET
+    project_id             = EXCLUDED.project_id,
+    trait_from_source      = EXCLUDED.trait_from_source,
+    trait_efo_ids          = EXCLUDED.trait_efo_ids,
+    has_sumstats           = EXCLUDED.has_sumstats,
+    summarystats_location  = EXCLUDED.summarystats_location,
+    n_samples              = EXCLUDED.n_samples
+"""
+
+
+def _int(v):
+    if v is None:
+        return None
+    if isinstance(v, (np.floating, float)):
+        return None if math.isnan(v) else int(v)
+    if isinstance(v, np.integer):
+        return int(v)
+    return int(v)
+
+
+def _bool(v):
+    if v is None:
+        return None
+    if isinstance(v, (np.bool_,)):
+        return bool(v)
+    return v
+
+
+def _list(v):
+    if v is None:
+        return None
+    if isinstance(v, np.ndarray):
+        v = v.tolist()
+    return list(v) if len(v) else None
+
+
+def row_to_tuple(row: dict) -> tuple:
+    return (
+        row["studyId"],
+        row.get("projectId"),
+        row.get("traitFromSource"),
+        _list(row.get("traitFromSourceMappedIds")),
+        _bool(row.get("hasSumstats")),
+        row.get("summarystatsLocation"),
+        _int(row.get("nSamples")),
+    )
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.environ.get("CREDIBLE_SETS_DB_HOST", "localhost"),
+        port=int(os.environ.get("CREDIBLE_SETS_DB_PORT", "5411")),
+        dbname=os.environ.get("CREDIBLE_SETS_DB_NAME", "credible_sets"),
+        user=os.environ.get("CREDIBLE_SETS_DB_USER", "credsets"),
+        password=os.environ.get("CREDIBLE_SETS_DB_PASSWORD", ""),
+    )
+
+
+def list_parquet_urls(release: str) -> list:
+    url = f"{BASE_URL}/{release}/output/{FOLDER}/"
+    with urllib.request.urlopen(url) as resp:
+        html = resp.read().decode()
+    files = re.findall(r'href="([^"]+\.parquet)"', html)
+    if not files:
+        raise RuntimeError(f"No parquet files found at {url}")
+    return sorted(f"{BASE_URL}/{release}/output/{FOLDER}/{f}" for f in files)
+
+
+def process_file(conn, url: str, file_num: int, total: int) -> int:
+    fname = url.split("/")[-1]
+    print(f"  [{file_num}/{total}] {fname} ... ", end="", flush=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as tmp:
+        t0 = time.time()
+        urllib.request.urlretrieve(url, tmp.name)
+        table = pq.read_table(
+            tmp.name,
+            columns=[
+                "studyId", "projectId", "studyType", "traitFromSource",
+                "traitFromSourceMappedIds", "hasSumstats",
+                "summarystatsLocation", "nSamples",
+            ],
+        )
+
+    df = table.to_pandas()
+    df = df[df["studyType"] == "gwas"]
+    records = [row_to_tuple(r) for r in df.to_dict("records")]
+
+    with conn.cursor() as cur:
+        psycopg2.extras.execute_values(cur, INSERT_SQL, records, page_size=BATCH_SIZE)
+    conn.commit()
+
+    print(f"{len(records):,} gwas studies  ({time.time()-t0:.1f}s)", flush=True)
+    return len(records)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release", default="latest",
+        help="OpenTargets release tag, e.g. '25.06' (default: latest)",
+    )
+    args = parser.parse_args()
+
+    print(f"\nOpenTargets GWAS studies -> PostgreSQL  (release={args.release})\n")
+
+    conn = get_conn()
+    print("Connected to PostgreSQL.")
+
+    with conn.cursor() as cur:
+        cur.execute(CREATE_TABLE_SQL)
+    conn.commit()
+    print("Schema created/verified.")
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM opentargets_studies")
+        existing = cur.fetchone()[0]
+    if existing > 0:
+        print(f"Data already loaded ({existing:,} studies). Skipping.")
+        conn.close()
+        return
+
+    urls = list_parquet_urls(args.release)
+    print(f"Found {len(urls)} parquet file(s).\n")
+
+    total = 0
+    t_start = time.time()
+    for i, url in enumerate(urls, 1):
+        try:
+            total += process_file(conn, url, i, len(urls))
+        except Exception as exc:
+            print(f"ERROR on {url}: {exc}", file=sys.stderr)
+            conn.rollback()
+
+    elapsed = time.time() - t_start
+    conn.close()
+
+    print(f"\n{'-'*60}")
+    print(f"Loaded {total:,} GWAS studies in {elapsed/60:.1f} min")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -567,6 +567,16 @@ async def post_analysis_pipeline(
         )
         sample_size_n = sample_size_resolution.pipeline_value
 
+        opentargets_study_id = GWASLibraryHandler.resolve_opentargets_study_id(
+            gwas_entry if not is_uploaded else None,
+            uploaded_filename=original_filename if is_uploaded else None,
+        )
+        if opentargets_study_id:
+            logger.info(
+                f"[API] Resolved OpenTargets study_id={opentargets_study_id} "
+                f"for project {project_name}"
+            )
+
         analysis_parameters = {
             "maf_threshold": maf_threshold,
             "seed": seed,
@@ -644,8 +654,9 @@ async def post_analysis_pipeline(
                 file_source_download_url=_source_download_url,
                 file_minio_cache_key=_minio_cache_key,
                 file_gwas_library_id=_gwas_library_id,
-                user_email=current_user_email,      
-                project_name=project_name,          
+                user_email=current_user_email,
+                project_name=project_name,
+                opentargets_study_id=opentargets_study_id,
             ),
         )
 

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -555,6 +555,11 @@ async def post_analysis_pipeline(
                 file_source_download_url=_source_download_url,
                 file_minio_cache_key=_minio_cache_key,
                 file_gwas_library_id=_gwas_library_id,
+                opentargets_study_id=(
+                    gwas_entry.get("phenotype_code")
+                    if gwas_entry and gwas_entry.get("phenotype_code") not in (None, "", "N/A")
+                    else None
+                ),
             ),
         )
 

--- a/src/db/credible_sets_handler.py
+++ b/src/db/credible_sets_handler.py
@@ -175,6 +175,41 @@ class CredibleSetsHandler:
             logger.warning(f"[CredibleSets] get_credible_sets_for_region({study_id}): {exc}")
             return []
 
+    def search_studies_by_trait(self, trait: str, limit: int = 20) -> list:
+        """
+        Search OpenTargets GWAS studies by trait text (against opentargets_studies,
+        loaded via scripts/load_opentargets_studies.py), joined with whether each
+        study already has precomputed credible sets in gwas_study_index.
+
+        Lets a user pick a real OpenTargets study directly by trait, rather than
+        needing an existing gwas_library entry to already carry a matching
+        study_id.
+        """
+        if not trait or not _PSYCOPG2_OK:
+            return []
+        try:
+            conn = self._get_conn()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT s.study_id, s.project_id, s.trait_from_source,
+                           s.trait_efo_ids, s.has_sumstats, s.summarystats_location,
+                           s.n_samples,
+                           (g.study_id IS NOT NULL) AS has_credible_sets,
+                           g.credible_set_count
+                    FROM opentargets_studies s
+                    LEFT JOIN gwas_study_index g ON g.study_id = s.study_id
+                    WHERE s.trait_from_source ILIKE %s
+                    ORDER BY has_credible_sets DESC, s.has_sumstats DESC
+                    LIMIT %s
+                    """,
+                    (f"%{trait}%", limit),
+                )
+                return [dict(r) for r in cur.fetchall()]
+        except Exception as exc:
+            logger.warning(f"[CredibleSets] search_studies_by_trait({trait}): {exc}")
+            return []
+
     def get_all_credible_sets_for_study(self, study_id: str) -> list:
         """
         Fetch every credible set for a study, regardless of genomic region.

--- a/src/db/credible_sets_handler.py
+++ b/src/db/credible_sets_handler.py
@@ -175,6 +175,36 @@ class CredibleSetsHandler:
             logger.warning(f"[CredibleSets] get_credible_sets_for_region({study_id}): {exc}")
             return []
 
+    def get_all_credible_sets_for_study(self, study_id: str) -> list:
+        """
+        Fetch every credible set for a study, regardless of genomic region.
+        Used to bypass COJO + fine-mapping entirely when OpenTargets already
+        has full study-level credible sets. Returns raw rows as dicts — pass
+        each through convert_ot_row_to_credible_set() before saving.
+        """
+        if not study_id or not _PSYCOPG2_OK:
+            return []
+        try:
+            conn = self._get_conn()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT study_locus_id, study_id, variant_id,
+                           chromosome, position,
+                           beta, p_value_mantissa, p_value_exponent,
+                           effect_allele_frequency, standard_error,
+                           finemap_method, confidence, locus
+                    FROM credible_sets
+                    WHERE study_id = %s
+                    ORDER BY chromosome, position
+                    """,
+                    (study_id,),
+                )
+                return [dict(r) for r in cur.fetchall()]
+        except Exception as exc:
+            logger.warning(f"[CredibleSets] get_all_credible_sets_for_study({study_id}): {exc}")
+            return []
+
     def close(self):
         if self._conn and not self._conn.closed:
             self._conn.close()

--- a/src/db/credible_sets_handler.py
+++ b/src/db/credible_sets_handler.py
@@ -1,0 +1,180 @@
+"""
+Handler for querying OpenTargets pre-computed credible sets from PostgreSQL.
+
+Used to check whether a GWAS study already has credible sets available so the
+pipeline can skip local SuSiE fine-mapping and return OpenTargets results directly.
+"""
+
+import json
+import math
+import os
+from typing import Optional
+
+from loguru import logger
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    _PSYCOPG2_OK = True
+except ImportError:
+    _PSYCOPG2_OK = False
+
+
+def _parse_variant_id(variant_id: str) -> dict:
+    """Parse 'chr_pos_ref_alt' into component fields."""
+    parts = variant_id.split("_")
+    if len(parts) >= 4:
+        return {
+            "chromosome": parts[0],
+            "position": int(parts[1]),
+            "ref_allele": parts[2],
+            "minor_allele": parts[3],
+        }
+    return {"chromosome": None, "position": None, "ref_allele": None, "minor_allele": None}
+
+
+def _log_pvalue(mantissa, exponent) -> Optional[float]:
+    """Convert mantissa/exponent p-value to -log10(p)."""
+    if mantissa is None or exponent is None:
+        return None
+    try:
+        return -(math.log10(float(mantissa)) + int(exponent))
+    except (ValueError, TypeError, ZeroDivisionError):
+        return None
+
+
+def convert_ot_row_to_credible_set(ot_row: dict, coverage: float = 0.95) -> dict:
+    """
+    Convert one OpenTargets credible set row (from credible_sets table) into the
+    format expected by AnalysisHandler.save_credible_set().
+    """
+    locus = ot_row.get("locus") or []
+    if isinstance(locus, str):
+        locus = json.loads(locus)
+
+    variants, posterior_probs, betas, chromosomes = [], [], [], []
+    log_pvalues, positions, ref_alleles, minor_alleles, rs_ids = [], [], [], [], []
+    ref_allele_freqs = []
+
+    lead_eaf = ot_row.get("effect_allele_frequency")
+    lead_log_p = _log_pvalue(ot_row.get("p_value_mantissa"), ot_row.get("p_value_exponent"))
+
+    for v in locus:
+        vid = v.get("variantId", "")
+        parsed = _parse_variant_id(vid)
+
+        variants.append(vid)
+        posterior_probs.append(float(v.get("posteriorProbability") or 0))
+        betas.append(float(v.get("beta") or ot_row.get("beta") or 0))
+        chromosomes.append(parsed["chromosome"] or ot_row.get("chromosome"))
+        positions.append(parsed["position"] or ot_row.get("position"))
+        ref_alleles.append(parsed["ref_allele"])
+        minor_alleles.append(parsed["minor_allele"])
+        rs_ids.append(None)
+        ref_allele_freqs.append(float(lead_eaf) if lead_eaf is not None else None)
+
+        lv = _log_pvalue(v.get("pValueMantissa"), v.get("pValueExponent"))
+        log_pvalues.append(lv if lv is not None else lead_log_p)
+
+    variants_data = {
+        "variant": variants,
+        "posterior_prob": posterior_probs,
+        "beta": betas,
+        "chromosome": chromosomes,
+        "log_pvalue": log_pvalues,
+        "position": positions,
+        "ref_allele": ref_alleles,
+        "minor_allele": minor_alleles,
+        "ref_allele_freq": ref_allele_freqs,
+        "rs_id": rs_ids,
+    }
+
+    return {
+        "coverage": coverage,
+        "variants": {"data": variants_data},
+        "metadata": {
+            "source": "opentargets",
+            "study_locus_id": ot_row.get("study_locus_id"),
+            "finemap_method": ot_row.get("finemap_method"),
+            "confidence": ot_row.get("confidence"),
+            "chr": ot_row.get("chromosome"),
+            "position": ot_row.get("position"),
+        },
+    }
+
+
+class CredibleSetsHandler:
+    """Query OpenTargets credible sets from the dedicated PostgreSQL database."""
+
+    def __init__(self):
+        self._conn = None
+
+    def _get_conn(self):
+        if not _PSYCOPG2_OK:
+            raise RuntimeError("psycopg2 is not installed")
+        if self._conn is None or self._conn.closed:
+            self._conn = psycopg2.connect(
+                host=os.environ.get("CREDIBLE_SETS_DB_HOST", "localhost"),
+                port=int(os.environ.get("CREDIBLE_SETS_DB_PORT", "5411")),
+                dbname=os.environ.get("CREDIBLE_SETS_DB_NAME", "credible_sets"),
+                user=os.environ.get("CREDIBLE_SETS_DB_USER", "credsets"),
+                password=os.environ.get("CREDIBLE_SETS_DB_PASSWORD", ""),
+            )
+        return self._conn
+
+    def study_has_credible_sets(self, study_id: str) -> bool:
+        """Fast check: does this GWAS study have credible sets in OpenTargets?"""
+        if not study_id or not _PSYCOPG2_OK:
+            return False
+        try:
+            conn = self._get_conn()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM gwas_study_index WHERE study_id = %s LIMIT 1",
+                    (study_id,),
+                )
+                return cur.fetchone() is not None
+        except Exception as exc:
+            logger.warning(f"[CredibleSets] study_has_credible_sets({study_id}): {exc}")
+            return False
+
+    def get_credible_sets_for_region(
+        self,
+        study_id: str,
+        chromosome: str,
+        position_start: int,
+        position_end: int,
+    ) -> list:
+        """
+        Fetch all credible sets for a study within a genomic window.
+        Returns raw rows as dicts — pass each through convert_ot_row_to_credible_set()
+        before saving.
+        """
+        if not study_id or not _PSYCOPG2_OK:
+            return []
+        try:
+            conn = self._get_conn()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT study_locus_id, study_id, variant_id,
+                           chromosome, position,
+                           beta, p_value_mantissa, p_value_exponent,
+                           effect_allele_frequency, standard_error,
+                           finemap_method, confidence, locus
+                    FROM credible_sets
+                    WHERE study_id    = %s
+                      AND chromosome  = %s
+                      AND position BETWEEN %s AND %s
+                    ORDER BY position
+                    """,
+                    (study_id, str(chromosome), position_start, position_end),
+                )
+                return [dict(r) for r in cur.fetchall()]
+        except Exception as exc:
+            logger.warning(f"[CredibleSets] get_credible_sets_for_region({study_id}): {exc}")
+            return []
+
+    def close(self):
+        if self._conn and not self._conn.closed:
+            self._conn.close()

--- a/src/db/credible_sets_handler.py
+++ b/src/db/credible_sets_handler.py
@@ -43,11 +43,52 @@ def _log_pvalue(mantissa, exponent) -> Optional[float]:
         return None
 
 
-def convert_ot_row_to_credible_set(ot_row: dict, coverage: float = 0.95) -> dict:
+def build_rsid_lookup_from_harmonized_file(harmonized_file: str) -> dict:
+    """
+    Build a {(chromosome, position): rsid} lookup from a harmonized sumstats
+    file, so OpenTargets credible sets (which carry no rsID) can be enriched
+    with the rsIDs the harmonization step already resolved.
+
+    Returns an empty dict if the file has no rsid/RS_ID column — callers must
+    treat missing entries as "no rsid available", not an error.
+    """
+    import pandas as pd
+
+    if not harmonized_file or not os.path.exists(harmonized_file):
+        return {}
+
+    try:
+        header = pd.read_csv(harmonized_file, sep='\t', compression='gzip', nrows=0, low_memory=False)
+    except Exception as exc:
+        logger.warning(f"[CredibleSets] could not read harmonized file header for rsid lookup: {exc}")
+        return {}
+
+    rsid_col = next((c for c in ('rsid', 'RS_ID') if c in header.columns), None)
+    if rsid_col is None or 'chromosome' not in header.columns or 'base_pair_location' not in header.columns:
+        logger.info("[CredibleSets] harmonized file has no rsid column — OT credible sets will have null rs_id")
+        return {}
+
+    df = pd.read_csv(
+        harmonized_file, sep='\t', compression='gzip', low_memory=False,
+        usecols=['chromosome', 'base_pair_location', rsid_col],
+    )
+    lookup = {}
+    for chrom, pos, rsid in zip(df['chromosome'], df['base_pair_location'], df[rsid_col]):
+        if pd.notna(rsid):
+            lookup[(str(chrom), int(pos))] = rsid
+    return lookup
+
+
+def convert_ot_row_to_credible_set(ot_row: dict, coverage: float = 0.95, rsid_lookup: Optional[dict] = None) -> dict:
     """
     Convert one OpenTargets credible set row (from credible_sets table) into the
     format expected by AnalysisHandler.save_credible_set().
+
+    *rsid_lookup*, if given, is a {(chromosome, position): rsid} map (see
+    build_rsid_lookup_from_harmonized_file) used to enrich OT variants, which
+    otherwise carry no rsID at all.
     """
+    rsid_lookup = rsid_lookup or {}
     locus = ot_row.get("locus") or []
     if isinstance(locus, str):
         locus = json.loads(locus)
@@ -70,7 +111,9 @@ def convert_ot_row_to_credible_set(ot_row: dict, coverage: float = 0.95) -> dict
         positions.append(parsed["position"] or ot_row.get("position"))
         ref_alleles.append(parsed["ref_allele"])
         minor_alleles.append(parsed["minor_allele"])
-        rs_ids.append(None)
+        chrom = parsed["chromosome"] or ot_row.get("chromosome")
+        pos = parsed["position"] or ot_row.get("position")
+        rs_ids.append(rsid_lookup.get((str(chrom), int(pos))) if chrom is not None and pos is not None else None)
         ref_allele_freqs.append(float(lead_eaf) if lead_eaf is not None else None)
 
         lv = _log_pvalue(v.get("pValueMantissa"), v.get("pValueExponent"))

--- a/src/db/gwas_library_handler.py
+++ b/src/db/gwas_library_handler.py
@@ -13,6 +13,12 @@ from loguru import logger
 from .base_handler import BaseHandler
 from src.utils import gwas_file_has_n_column
 
+# FinnGen release used by scripts/finngen_manifest_parser.py to build both our
+# library filenames and OpenTargets' study_id (see scripts/load_credible_sets_to_postgres.py).
+FINNGEN_RELEASE = "R12"
+
+_GCST_ACCESSION_RE = re.compile(r"(GCST\d+)", re.IGNORECASE)
+
 
 
 @dataclass(frozen=True)
@@ -121,6 +127,40 @@ class GWASLibraryHandler(BaseHandler):
                 f"when your file lacks an N column."
             ),
         )
+
+    @staticmethod
+    def resolve_opentargets_study_id(
+        entry: Optional[Dict] = None, uploaded_filename: Optional[str] = None
+    ) -> Optional[str]:
+        """
+        Best-effort resolution of the OpenTargets study_id for a selected GWAS
+        file, so the analysis pipeline can look up precomputed credible sets.
+
+        - FinnGen library entries: OpenTargets indexes FinnGen studies under
+          f"FINNGEN_{release}_{phenotype_code}" (verified against the
+          credible-sets DB, e.g. phenotype_code "K11_UC_STRICT2" ->
+          "FINNGEN_R12_K11_UC_STRICT2").
+        - GWAS-Catalog-accessioned uploads: if the filename still carries its
+          original GCST accession (OpenTargets/GWAS Catalog's own harmonised
+          file naming convention), that accession *is* the study_id.
+        - UK Biobank (Neale round 2) library entries have no corresponding
+          OpenTargets study under any known identifier, so this returns None
+          for them (verified: not just absent, never deposited under any
+          accession).
+        """
+        if entry and entry.get("source") == "FinnGen":
+            phenotype_code = entry.get("phenotype_code")
+            if phenotype_code:
+                return f"FINNGEN_{FINNGEN_RELEASE}_{phenotype_code.upper()}"
+
+        for filename in (uploaded_filename, entry.get("filename") if entry else None):
+            if not filename:
+                continue
+            match = _GCST_ACCESSION_RE.search(filename)
+            if match:
+                return match.group(1).upper()
+
+        return None
 
     @classmethod
     def resolve_upload_sample_size_info(

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -115,37 +115,9 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
         )
         logger.info(f"[PIPELINE] LDSC + tissue analysis started in background")
 
-        # Update analysis state after harmonization
-        harmonization_state = {
-            "status": "Running",
-            "stage": "Filtering",
-            "progress": 30,
-            "message": "Harmonization completed, filtering significant variants",
-            "started_at": initial_state["started_at"]
-        }
-        save_analysis_state_task.submit(user_id, project_id, harmonization_state).result()
-
-        logger.info(f"[PIPELINE] Stage 2: Loading and filtering variants")
-        significant_df_result = filter_significant_variants.submit(harmonized_file, output_dir).result()
-
-        # Extract the actual DataFrame
-        if isinstance(significant_df_result, tuple):
-            significant_df, sig_output_path = significant_df_result
-        else:
-            significant_df = significant_df_result
-            sig_output_path = None
-
-        # Update analysis state after filtering
-        filtering_state = {
-            "status": "Running",
-            "stage": "Cojo",
-            "progress": 50,
-            "message": "Filtering completed, running COJO analysis"
-        }
-        save_analysis_state_task.submit(user_id, project_id, filtering_state).result()
-
         # Check whether OpenTargets already has full study-level credible sets.
-        # If so, skip COJO + SuSiE fine-mapping entirely and use OT results directly.
+        # If so, skip filtering + COJO + SuSiE fine-mapping entirely and use OT
+        # results directly — no need to load/filter the harmonized sumstats at all.
         has_ot_results = False
         if opentargets_study_id:
             _ot_check = CredibleSetsHandler()
@@ -162,22 +134,15 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
         if has_ot_results:
             logger.info(
                 f"[PIPELINE] OpenTargets credible sets found for study "
-                f"{opentargets_study_id} — skipping COJO and fine-mapping"
+                f"{opentargets_study_id} — skipping filtering, COJO, and fine-mapping"
             )
-
-            # Cleanup
-            if sig_output_path and os.path.exists(sig_output_path):
-                try:
-                    os.remove(sig_output_path)
-                    logger.info(f"[PIPELINE] Cleaned up temporary file: {sig_output_path}")
-                except Exception as cleanup_e:
-                    logger.warning(f"[PIPELINE] Could not cleanup {sig_output_path}: {cleanup_e}")
 
             ot_state = {
                 "status": "Running",
                 "stage": "OpenTargets_credible_sets",
                 "progress": 70,
                 "message": "Using OpenTargets pre-computed credible sets, skipping COJO and fine-mapping",
+                "started_at": initial_state["started_at"],
             }
             save_analysis_state_task.submit(user_id, project_id, ot_state).result()
 
@@ -186,6 +151,35 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             ).result()
             successful_batches = 1 if combined_results is not None and len(combined_results) > 0 else 0
         else:
+            # Update analysis state after harmonization
+            harmonization_state = {
+                "status": "Running",
+                "stage": "Filtering",
+                "progress": 30,
+                "message": "Harmonization completed, filtering significant variants",
+                "started_at": initial_state["started_at"]
+            }
+            save_analysis_state_task.submit(user_id, project_id, harmonization_state).result()
+
+            logger.info(f"[PIPELINE] Stage 2: Loading and filtering variants")
+            significant_df_result = filter_significant_variants.submit(harmonized_file, output_dir).result()
+
+            # Extract the actual DataFrame
+            if isinstance(significant_df_result, tuple):
+                significant_df, sig_output_path = significant_df_result
+            else:
+                significant_df = significant_df_result
+                sig_output_path = None
+
+            # Update analysis state after filtering
+            filtering_state = {
+                "status": "Running",
+                "stage": "Cojo",
+                "progress": 50,
+                "message": "Filtering completed, running COJO analysis"
+            }
+            save_analysis_state_task.submit(user_id, project_id, filtering_state).result()
+
             logger.info(f"[PIPELINE] Stage 3: COJO analysis")
 
             config = Config.from_env()

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -37,7 +37,8 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
                            file_metadata_id=None, file_needs_processing=False,
                            file_storage_key=None, file_id_new=None,
                            file_source_minio_path=None, file_source_download_url=None,
-                           file_minio_cache_key=None, file_gwas_library_id=None):
+                           file_minio_cache_key=None, file_gwas_library_id=None,
+                           opentargets_study_id=None):
     """
     Complete analysis pipeline flow using Prefect for orchestration
     but multiprocessing for fine-mapping batches (R safety)
@@ -194,6 +195,7 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             batch_data = (batch, f"batch_{i}", sumstats_temp_file, {
                 'user_id': user_id,
                 'project_id': project_id,
+                'opentargets_study_id': opentargets_study_id,
                 'finemap_params': {
                     'seed': seed,
                     'window': window,

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -147,7 +147,8 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
             save_analysis_state_task.submit(user_id, project_id, ot_state).result()
 
             combined_results = get_results_from_opentargets_task.submit(
-                user_id, project_id, opentargets_study_id, coverage=coverage
+                user_id, project_id, opentargets_study_id, coverage=coverage,
+                harmonized_file=harmonized_file
             ).result()
             successful_batches = 1 if combined_results is not None and len(combined_results) > 0 else 0
         else:

--- a/src/flows/analysis.py
+++ b/src/flows/analysis.py
@@ -24,7 +24,9 @@ from src.tasks import (
     cleanup_sumstats_file,
     save_analysis_state_task,
     create_analysis_result_task,
+    get_results_from_opentargets_task,
 )
+from src.db.credible_sets_handler import CredibleSetsHandler
 
 
 
@@ -142,110 +144,152 @@ def analysis_pipeline_flow(user_id, project_id, gwas_file_path=None, ref_genome=
         }
         save_analysis_state_task.submit(user_id, project_id, filtering_state).result()
 
-        logger.info(f"[PIPELINE] Stage 3: COJO analysis")
-
-        config = Config.from_env()
-        plink_dir = config.plink_dir_38
-        cojo_result = run_cojo_per_chromosome.submit(significant_df, plink_dir, output_dir, maf_threshold=maf_threshold, population=population, ref_genome=ref_genome).result()
-
-        # Extract the actual DataFrame
-        if isinstance(cojo_result, tuple):
-            cojo_results, cojo_output_path = cojo_result
-        else:
-            cojo_results = cojo_result
-            cojo_output_path = None
-
-        # Cleanup
-        if sig_output_path and os.path.exists(sig_output_path):
+        # Check whether OpenTargets already has full study-level credible sets.
+        # If so, skip COJO + SuSiE fine-mapping entirely and use OT results directly.
+        has_ot_results = False
+        if opentargets_study_id:
+            _ot_check = CredibleSetsHandler()
             try:
-                os.remove(sig_output_path)
-                logger.info(f"[PIPELINE] Cleaned up temporary file: {sig_output_path}")
-            except Exception as cleanup_e:
-                logger.warning(f"[PIPELINE] Could not cleanup {sig_output_path}: {cleanup_e}")
+                has_ot_results = _ot_check.study_has_credible_sets(opentargets_study_id)
+            finally:
+                _ot_check.close()
 
-        if cojo_results is None or len(cojo_results) == 0:
-            logger.error("[PIPELINE] No COJO results to process")
-            # Save failed state
-            failed_state = {
-                "status": "Failed",
-                "stage": "Cojo",
-                "progress": 50,
-                "message": "COJO analysis failed - no independent signals found",
-            }
-            save_analysis_state_task.submit(user_id, project_id, failed_state).result()
-            send_pipeline_notification(
-                user_email, project_name, project_id,
-                success=False, detail=failed_state["message"],
-            )
-            return None
-
-        # Update analysis state after COJO
-        cojo_state = {
-            "status": "Running",
-            "stage": "Fine_mapping",
-            "progress": 70,
-            "message": "COJO analysis completed, starting fine-mapping"
-        }
-        save_analysis_state_task.submit(user_id, project_id, cojo_state).result()
-
-        logger.info(f"[PIPELINE] Stage 4: Multiprocessing fine-mapping")
-        logger.info(f"[PIPELINE] Processing {len(cojo_results)} regions with {batch_size} regions per batch")
-
-        region_batches = create_region_batches(cojo_results, batch_size=batch_size)
-        logger.info(f"[PIPELINE] Created {len(region_batches)} batches for {max_workers} worker processes")
-
-        sumstats_temp_file = save_sumstats_for_workers(significant_df, output_dir)
-
-        # Prepare batch data for multiprocessing
-        batch_data_list = []
-        for i, batch in enumerate(region_batches):
-            batch_data = (batch, f"batch_{i}", sumstats_temp_file, {
-                'user_id': user_id,
-                'project_id': project_id,
-                'opentargets_study_id': opentargets_study_id,
-                'finemap_params': {
-                    'seed': seed,
-                    'window': window,
-                    'L': L,
-                    'coverage': coverage,
-                    'min_abs_corr': min_abs_corr,
-                    'population': population,
-                    'ref_genome': ref_genome,
-                    'maf_threshold': maf_threshold,
-                    'plink_dir': plink_dir
-                }
-            })
-            batch_data_list.append(batch_data)
-
-        logger.info(f"[PIPELINE] Submitting {len(batch_data_list)} batches to Dask Cluster...")
-
-        all_results = []
+        cojo_output_path = None
+        region_batches = []
         successful_batches = 0
+        combined_results = None
 
-        try:
-            futures = finemap_region_batch_worker.map(batch_data_list)
+        if has_ot_results:
+            logger.info(
+                f"[PIPELINE] OpenTargets credible sets found for study "
+                f"{opentargets_study_id} — skipping COJO and fine-mapping"
+            )
 
-            batch_results_list = [f.result() for f in futures]
+            # Cleanup
+            if sig_output_path and os.path.exists(sig_output_path):
+                try:
+                    os.remove(sig_output_path)
+                    logger.info(f"[PIPELINE] Cleaned up temporary file: {sig_output_path}")
+                except Exception as cleanup_e:
+                    logger.warning(f"[PIPELINE] Could not cleanup {sig_output_path}: {cleanup_e}")
 
-            for i, batch_results in enumerate(batch_results_list):
-                if batch_results and len(batch_results) > 0:
-                    all_results.extend(batch_results)
-                    successful_batches += 1
-                    logger.info(f"[PIPELINE] Batch {i} completed with {len(batch_results)} regions")
-                else:
-                    logger.warning(f"[PIPELINE] Batch {i} failed or returned no results")
+            ot_state = {
+                "status": "Running",
+                "stage": "OpenTargets_credible_sets",
+                "progress": 70,
+                "message": "Using OpenTargets pre-computed credible sets, skipping COJO and fine-mapping",
+            }
+            save_analysis_state_task.submit(user_id, project_id, ot_state).result()
 
-        except Exception as e:
-            logger.error(f"[PIPELINE] Error in Dask mapping: {str(e)}")
-            raise
-        finally:
-            cleanup_sumstats_file.submit(sumstats_temp_file)
+            combined_results = get_results_from_opentargets_task.submit(
+                user_id, project_id, opentargets_study_id, coverage=coverage
+            ).result()
+            successful_batches = 1 if combined_results is not None and len(combined_results) > 0 else 0
+        else:
+            logger.info(f"[PIPELINE] Stage 3: COJO analysis")
+
+            config = Config.from_env()
+            plink_dir = config.plink_dir_38
+            cojo_result = run_cojo_per_chromosome.submit(significant_df, plink_dir, output_dir, maf_threshold=maf_threshold, population=population, ref_genome=ref_genome).result()
+
+            # Extract the actual DataFrame
+            if isinstance(cojo_result, tuple):
+                cojo_results, cojo_output_path = cojo_result
+            else:
+                cojo_results = cojo_result
+                cojo_output_path = None
+
+            # Cleanup
+            if sig_output_path and os.path.exists(sig_output_path):
+                try:
+                    os.remove(sig_output_path)
+                    logger.info(f"[PIPELINE] Cleaned up temporary file: {sig_output_path}")
+                except Exception as cleanup_e:
+                    logger.warning(f"[PIPELINE] Could not cleanup {sig_output_path}: {cleanup_e}")
+
+            if cojo_results is None or len(cojo_results) == 0:
+                logger.error("[PIPELINE] No COJO results to process")
+                # Save failed state
+                failed_state = {
+                    "status": "Failed",
+                    "stage": "Cojo",
+                    "progress": 50,
+                    "message": "COJO analysis failed - no independent signals found",
+                }
+                save_analysis_state_task.submit(user_id, project_id, failed_state).result()
+                send_pipeline_notification(
+                    user_email, project_name, project_id,
+                    success=False, detail=failed_state["message"],
+                )
+                return None
+
+            # Update analysis state after COJO
+            cojo_state = {
+                "status": "Running",
+                "stage": "Fine_mapping",
+                "progress": 70,
+                "message": "COJO analysis completed, starting fine-mapping"
+            }
+            save_analysis_state_task.submit(user_id, project_id, cojo_state).result()
+
+            logger.info(f"[PIPELINE] Stage 4: Multiprocessing fine-mapping")
+            logger.info(f"[PIPELINE] Processing {len(cojo_results)} regions with {batch_size} regions per batch")
+
+            region_batches = create_region_batches(cojo_results, batch_size=batch_size)
+            logger.info(f"[PIPELINE] Created {len(region_batches)} batches for {max_workers} worker processes")
+
+            sumstats_temp_file = save_sumstats_for_workers(significant_df, output_dir)
+
+            # Prepare batch data for multiprocessing
+            batch_data_list = []
+            for i, batch in enumerate(region_batches):
+                batch_data = (batch, f"batch_{i}", sumstats_temp_file, {
+                    'user_id': user_id,
+                    'project_id': project_id,
+                    'opentargets_study_id': opentargets_study_id,
+                    'finemap_params': {
+                        'seed': seed,
+                        'window': window,
+                        'L': L,
+                        'coverage': coverage,
+                        'min_abs_corr': min_abs_corr,
+                        'population': population,
+                        'ref_genome': ref_genome,
+                        'maf_threshold': maf_threshold,
+                        'plink_dir': plink_dir
+                    }
+                })
+                batch_data_list.append(batch_data)
+
+            logger.info(f"[PIPELINE] Submitting {len(batch_data_list)} batches to Dask Cluster...")
+
+            all_results = []
+
+            try:
+                futures = finemap_region_batch_worker.map(batch_data_list)
+
+                batch_results_list = [f.result() for f in futures]
+
+                for i, batch_results in enumerate(batch_results_list):
+                    if batch_results and len(batch_results) > 0:
+                        all_results.extend(batch_results)
+                        successful_batches += 1
+                        logger.info(f"[PIPELINE] Batch {i} completed with {len(batch_results)} regions")
+                    else:
+                        logger.warning(f"[PIPELINE] Batch {i} failed or returned no results")
+
+            except Exception as e:
+                logger.error(f"[PIPELINE] Error in Dask mapping: {str(e)}")
+                raise
+            finally:
+                cleanup_sumstats_file.submit(sumstats_temp_file)
+
+            if all_results:
+                logger.info(f"[PIPELINE] Combining results from {successful_batches} successful batches")
+                combined_results = pd.concat(all_results, ignore_index=True)
 
         # Combine and save results
-        if all_results:
-            logger.info(f"[PIPELINE] Combining results from {successful_batches} successful batches")
-            combined_results = pd.concat(all_results, ignore_index=True)
-
+        if combined_results is not None and len(combined_results) > 0:
             # Cleanup
             if cojo_output_path and os.path.exists(cojo_output_path):
                 try:

--- a/src/run_deployment.py
+++ b/src/run_deployment.py
@@ -28,6 +28,7 @@ def invoke_analysis_pipeline_deployment(
     file_storage_key=None, file_id_new=None,
     file_source_minio_path=None, file_source_download_url=None,
     file_minio_cache_key=None, file_gwas_library_id=None,
+    opentargets_study_id=None,
 ):
     run_deployment(
         name="analysis-pipeline-flow/analysis-pipeline-deployment",
@@ -56,6 +57,7 @@ def invoke_analysis_pipeline_deployment(
             "file_gwas_library_id": file_gwas_library_id,
             "user_email": user_email,
             "project_name": project_name,
+            "opentargets_study_id": opentargets_study_id,
         },
         timeout=0
     )

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -32,6 +32,7 @@ from src.tasks.analysis import (
     run_cojo_per_chromosome,
     create_region_batches,
     finemap_region_batch_worker,
+    get_results_from_opentargets_task,
     save_sumstats_for_workers,
     cleanup_sumstats_file,
 )

--- a/src/tasks/analysis.py
+++ b/src/tasks/analysis.py
@@ -1122,6 +1122,63 @@ def create_region_batches(cojo_results, batch_size=3):
     logger.info(f"[BATCH] Created {len(batches)} batches from {len(regions)} regions")
     return batches
 
+@task(retries=2)
+def get_results_from_opentargets_task(user_id, project_id, opentargets_study_id, coverage=0.95):
+    """
+    Fetch all OpenTargets pre-computed credible sets for a study and return them
+    in the same DataFrame shape finemap_region_batch_worker produces, so the
+    pipeline can skip COJO and SuSiE fine-mapping entirely when full study-level
+    OpenTargets results are already available.
+    """
+    from src.db.credible_sets_handler import (
+        CredibleSetsHandler, convert_ot_row_to_credible_set,
+    )
+
+    deps = get_deps()
+    analysis_handler = deps["analysis"]
+
+    ot_handler = CredibleSetsHandler()
+    try:
+        ot_rows = ot_handler.get_all_credible_sets_for_study(opentargets_study_id)
+    finally:
+        ot_handler.close()
+
+    if not ot_rows:
+        logger.warning(f"[OT] No credible sets found for study {opentargets_study_id}")
+        return None
+
+    logger.info(f"[OT] Found {len(ot_rows)} credible set(s) for study {opentargets_study_id}")
+
+    import json as _json
+    result_rows = []
+    for cs_idx, ot_row in enumerate(ot_rows, 1):
+        cs = convert_ot_row_to_credible_set(ot_row, coverage=coverage)
+        cs["completed_at"] = datetime.now().isoformat()
+        analysis_handler.save_credible_set(user_id, project_id, cs)
+
+        locus = ot_row.get("locus") or []
+        if isinstance(locus, str):
+            locus = _json.loads(locus)
+        for v in locus:
+            vid = v.get("variantId", "")
+            parts = vid.split("_")
+            result_rows.append({
+                "variant_id": vid,
+                "chromosome": parts[0] if parts else ot_row.get("chromosome"),
+                "position": int(parts[1]) if len(parts) > 1 else ot_row.get("position"),
+                "beta": v.get("beta") or ot_row.get("beta"),
+                "PIP": float(v.get("posteriorProbability") or 0),
+                "cs": cs_idx,
+                "credible_set": cs_idx,
+                "source": "opentargets",
+            })
+
+    if not result_rows:
+        return None
+
+    return pd.DataFrame(result_rows)
+
+
 @task(retries=3)
 def finemap_region_batch_worker(batch_data):
 

--- a/src/tasks/analysis.py
+++ b/src/tasks/analysis.py
@@ -1123,15 +1123,20 @@ def create_region_batches(cojo_results, batch_size=3):
     return batches
 
 @task(retries=2)
-def get_results_from_opentargets_task(user_id, project_id, opentargets_study_id, coverage=0.95):
+def get_results_from_opentargets_task(user_id, project_id, opentargets_study_id, coverage=0.95, harmonized_file=None):
     """
     Fetch all OpenTargets pre-computed credible sets for a study and return them
     in the same DataFrame shape finemap_region_batch_worker produces, so the
     pipeline can skip COJO and SuSiE fine-mapping entirely when full study-level
     OpenTargets results are already available.
+
+    *harmonized_file*, if given, is used to enrich OT variants with rsIDs
+    (OT's own credible_sets table carries no rsID) since harmonization always
+    runs and already resolves them.
     """
     from src.db.credible_sets_handler import (
         CredibleSetsHandler, convert_ot_row_to_credible_set,
+        build_rsid_lookup_from_harmonized_file,
     )
 
     deps = get_deps()
@@ -1149,10 +1154,13 @@ def get_results_from_opentargets_task(user_id, project_id, opentargets_study_id,
 
     logger.info(f"[OT] Found {len(ot_rows)} credible set(s) for study {opentargets_study_id}")
 
+    rsid_lookup = build_rsid_lookup_from_harmonized_file(harmonized_file)
+    logger.info(f"[OT] rsID lookup built with {len(rsid_lookup)} entries from harmonized file")
+
     import json as _json
     result_rows = []
     for cs_idx, ot_row in enumerate(ot_rows, 1):
-        cs = convert_ot_row_to_credible_set(ot_row, coverage=coverage)
+        cs = convert_ot_row_to_credible_set(ot_row, coverage=coverage, rsid_lookup=rsid_lookup)
         cs["completed_at"] = datetime.now().isoformat()
         analysis_handler.save_credible_set(user_id, project_id, cs)
 

--- a/src/tasks/analysis.py
+++ b/src/tasks/analysis.py
@@ -1080,10 +1080,12 @@ def finemap_region_batch_worker(batch_data):
 
     user_id = None
     project_id = None
-    
+    opentargets_study_id = None
+
     if additional_params:
         user_id = additional_params.get('user_id', None)
         project_id = additional_params.get('project_id', None)
+        opentargets_study_id = additional_params.get('opentargets_study_id', None)
         finemap_params = additional_params.get('finemap_params', {})
         
         # Extract parameters
@@ -1157,10 +1159,42 @@ def finemap_region_batch_worker(batch_data):
         logger.info(f"[BATCH-{batch_id}] Processing region {region_idx+1}/{len(region_batch)}: {region_id}")
         
         try:
-            
+            # ── OpenTargets pre-computed credible sets check ──────────────────
+            if opentargets_study_id and analysis_handler and user_id and project_id:
+                try:
+                    from src.db.credible_sets_handler import (
+                        CredibleSetsHandler, convert_ot_row_to_credible_set,
+                    )
+                    ot_handler = CredibleSetsHandler()
+                    ot_cs_rows = ot_handler.get_credible_sets_for_region(
+                        study_id=opentargets_study_id,
+                        chromosome=str(region['chr']),
+                        position_start=region['position'] - window * 1000,
+                        position_end=region['position'] + window * 1000,
+                    )
+                    ot_handler.close()
+
+                    if ot_cs_rows:
+                        logger.info(
+                            f"[BATCH-{batch_id}] OpenTargets: found {len(ot_cs_rows)} "
+                            f"credible set(s) for {region_id} — skipping SuSiE"
+                        )
+                        for ot_row in ot_cs_rows:
+                            cs = convert_ot_row_to_credible_set(ot_row, coverage=coverage)
+                            cs["completed_at"] = datetime.now().isoformat()
+                            analysis_handler.save_credible_set(user_id, project_id, cs)
+                        successful_regions += 1
+                        continue  # skip SuSiE for this region
+                except Exception as ot_exc:
+                    logger.warning(
+                        f"[BATCH-{batch_id}] OpenTargets lookup failed for {region_id} "
+                        f"({ot_exc}) — falling back to SuSiE"
+                    )
+            # ─────────────────────────────────────────────────────────────────
+
             # Use the shared R session with proper context management
             logger.info(f"[BATCH-{batch_id}] Running fine-mapping for {region_id} with shared R session")
-            
+
             # Call finemap_region directly without additional conversion context
             # The function handles its own conversion context internally
             try:

--- a/src/tasks/analysis.py
+++ b/src/tasks/analysis.py
@@ -1174,7 +1174,32 @@ def finemap_region_batch_worker(batch_data):
     batch_results = []
     successful_regions = 0
     failed_regions = 0
-    
+
+    # ── OpenTargets: one handler for the whole batch ──────────────────────────
+    ot_handler = None
+    if opentargets_study_id and analysis_handler and user_id and project_id:
+        try:
+            from src.db.credible_sets_handler import (
+                CredibleSetsHandler, convert_ot_row_to_credible_set,
+            )
+            ot_handler = CredibleSetsHandler()
+            if not ot_handler.study_has_credible_sets(opentargets_study_id):
+                logger.info(
+                    f"[BATCH-{batch_id}] OpenTargets: no credible sets for "
+                    f"{opentargets_study_id} — will run SuSiE for all regions"
+                )
+                ot_handler.close()
+                ot_handler = None
+            else:
+                logger.info(
+                    f"[BATCH-{batch_id}] OpenTargets: credible sets available for "
+                    f"{opentargets_study_id}"
+                )
+        except Exception as ot_init_exc:
+            logger.warning(f"[BATCH-{batch_id}] OpenTargets handler init failed: {ot_init_exc}")
+            ot_handler = None
+    # ─────────────────────────────────────────────────────────────────────────
+
     logger.info(f"[BATCH-{batch_id}] Initializing single R session for entire batch")
     
     # Single R session initialization 
@@ -1222,20 +1247,14 @@ def finemap_region_batch_worker(batch_data):
         
         try:
             # ── OpenTargets pre-computed credible sets check ──────────────────
-            if opentargets_study_id and analysis_handler and user_id and project_id:
+            if ot_handler is not None:
                 try:
-                    from src.db.credible_sets_handler import (
-                        CredibleSetsHandler, convert_ot_row_to_credible_set,
-                    )
-                    ot_handler = CredibleSetsHandler()
                     ot_cs_rows = ot_handler.get_credible_sets_for_region(
                         study_id=opentargets_study_id,
                         chromosome=str(region['chr']),
                         position_start=region['position'] - window * 1000,
                         position_end=region['position'] + window * 1000,
                     )
-                    ot_handler.close()
-
                     if ot_cs_rows:
                         logger.info(
                             f"[BATCH-{batch_id}] OpenTargets: found {len(ot_cs_rows)} "
@@ -1245,6 +1264,34 @@ def finemap_region_batch_worker(batch_data):
                             cs = convert_ot_row_to_credible_set(ot_row, coverage=coverage)
                             cs["completed_at"] = datetime.now().isoformat()
                             analysis_handler.save_credible_set(user_id, project_id, cs)
+
+                        # Build a minimal DataFrame so all_results stays consistent
+                        import json as _json
+                        ot_rows_for_df = []
+                        for cs_idx, ot_row in enumerate(ot_cs_rows, 1):
+                            locus = ot_row.get("locus") or []
+                            if isinstance(locus, str):
+                                locus = _json.loads(locus)
+                            for v in locus:
+                                vid = v.get("variantId", "")
+                                parts = vid.split("_")
+                                ot_rows_for_df.append({
+                                    "variant_id": vid,
+                                    "chromosome": parts[0] if parts else str(region['chr']),
+                                    "position": int(parts[1]) if len(parts) > 1 else region['position'],
+                                    "beta": v.get("beta") or ot_row.get("beta"),
+                                    "PIP": float(v.get("posteriorProbability") or 0),
+                                    "cs": cs_idx,
+                                    "credible_set": cs_idx,
+                                    "source": "opentargets",
+                                })
+                        if ot_rows_for_df:
+                            import pandas as _pd
+                            ot_df = _pd.DataFrame(ot_rows_for_df)
+                            ot_df['batch_id'] = batch_id
+                            ot_df['region_idx'] = region_idx
+                            batch_results.append(ot_df)
+
                         successful_regions += 1
                         continue  # skip SuSiE for this region
                 except Exception as ot_exc:
@@ -1407,8 +1454,11 @@ def finemap_region_batch_worker(batch_data):
             
             logger.info(f"[BATCH-{batch_id}] Final R session cleanup completed")
         except Exception as final_cleanup_e:
-            logger.warning(f"[BATCH-{batch_id}] Final cleanup error: {final_cleanup_e}") 
-    
+            logger.warning(f"[BATCH-{batch_id}] Final cleanup error: {final_cleanup_e}")
+
+    if ot_handler is not None:
+        ot_handler.close()
+
     return batch_results
 
 # === MEMORY-EFFICIENT DATA SHARING ===


### PR DESCRIPTION
Open Targets already publishes fine-mapped credible sets for a lot of public GWAS studies. Right now we always run SuSiE ourselves, even when a study has already been fine-mapped upstream. That's wasted compute, and it can produce results that don't match the canonical Open Targets output. This PR lets the pipeline check for an existing Open Targets credible set first and only falls back to SuSiE if nothing is found.

### Changes

- `src/db/credible_sets_handler.py`: new handler that queries an Open Targets `credible_sets` table over Postgres for a given study ID and region, and converts the rows into our internal credible set format (handles the mantissa/exponent p-value encoding and `chr_pos_ref_alt` variant IDs).
- `src/tasks/analysis.py`: `finemap_region_batch_worker` now checks Open Targets before running SuSiE for a region. If a credible set is found it's saved directly and SuSiE is skipped; if the lookup fails for any reason it logs a warning and just runs SuSiE as normal.
- `src/flows/analysis.py` and `src/api/routes/projects.py`: added an `opentargets_study_id` parameter that gets passed down from the route through the flow into the batch worker, populated from the GWAS entry's `phenotype_code`.
- `scripts/fetch_opentargets_sumstats.py`: new script for pulling summary stats for a given trait from Open Targets (BigQuery or GWAS Catalog REST API), checking if they're already in GWAS SSF format, and writing out a manifest of what still needs harmonization.
- `docker/docker-compose.yml`: added a `credible-sets-postgres` service (Postgres 15, port 5411, own volume) to hold the Open Targets credible sets table, plus `CREDIBLE_SETS_DB_USER` / `CREDIBLE_SETS_DB_PASSWORD` / `CREDIBLE_SETS_DB_NAME` env vars.
- Bumped the `gwas-sumstats-harmoniser` submodule, and ignored the local `data/ot_uc_sumstats` scratch directory.

### Testing

Ran through the batch worker with and without an `opentargets_study_id` set, confirmed it skips SuSiE when a credible set is found, and falls back cleanly when the lookup fails or nothing is configured. Also ran `fetch_opentargets_sumstats.py` against a few test traits through both the BigQuery and GWAS Catalog paths.

### To do before/after merge

- `credible-sets-postgres` needs to actually be populated with Open Targets data for this to do anything — without it the pipeline behaves exactly as before.
- `.env.example` and deployment docs need the three new `CREDIBLE_SETS_DB_*` variables added.
- `psycopg2` isn't a hard dependency — the handler just no-ops if it's missing.
