### PR TITLE
Support writes (hypothesis generation) on forked/demo projects

### DIFF
--- a/src/api/routes/hypothesis.py
+++ b/src/api/routes/hypothesis.py
@@ -13,6 +13,7 @@ from src.api.dependencies import (
     get_gene_expression_handler,
     get_hypothesis_handler,
     get_llm,
+    get_project_handler,
 )
 from src.api.auth import get_current_user_id
 from src.db import (
@@ -20,8 +21,12 @@ from src.db import (
     EnrichmentHandler,
     GeneExpressionHandler,
     HypothesisHandler,
+    ProjectHandler,
 )
-from src.services.demo import resolve_hypothesis_data_user_id
+from src.services.demo import (
+    resolve_enrich_and_hypothesis_for_write,
+    resolve_hypothesis_data_user_id,
+)
 from src.services.llm import LLM
 from src.run_deployment import invoke_hypothesis_deployment
 from src.services.status_tracker import TaskState, status_tracker
@@ -37,12 +42,26 @@ router = APIRouter()
 _HYPOTHESIS_FLOW_WAIT_TIMEOUT = float(os.getenv("HYPOTHESIS_FLOW_WAIT_TIMEOUT", "120"))
 
 
-def _response_from_hypothesis_document(hypothesis_id: str, doc: dict | None) -> dict:
-    return {
+def _response_from_hypothesis_document(
+    hypothesis_id: str,
+    doc: dict | None,
+    *,
+    enrich_id: str | None = None,
+    project_id: str | None = None,
+    forked: bool = False,
+) -> dict:
+    response = {
         "id": hypothesis_id,
+        "hypothesis_id": hypothesis_id,
         "summary": doc.get("summary") if doc else None,
         "graph": doc.get("graph") if doc else None,
     }
+    if enrich_id is not None:
+        response["enrich_id"] = enrich_id
+    if project_id is not None:
+        response["project_id"] = project_id
+    response["forked"] = forked
+    return response
 
 
 @router.get("/hypothesis")
@@ -226,6 +245,10 @@ async def post_hypothesis(
     go: str | None = Query(None),
     current_user_id: str = Depends(get_current_user_id),
     hypotheses: HypothesisHandler = Depends(get_hypothesis_handler),
+    enrichment: EnrichmentHandler = Depends(get_enrichment_handler),
+    projects: ProjectHandler = Depends(get_project_handler),
+    demo_templates: DemoTemplateHandler = Depends(get_demo_template_handler),
+    gene_expression: GeneExpressionHandler = Depends(get_gene_expression_handler),
 ):
     """Generate hypothesis synchronously and return graph + summary immediately."""
     enrich_id = id
@@ -234,19 +257,27 @@ async def post_hypothesis(
     if not go_id:
         raise HTTPException(status_code=400, detail="go (GO term ID) is required")
 
-    hypothesis = hypotheses.get_hypothesis_by_enrich(current_user_id, enrich_id)
-    if not hypothesis:
+    resolved = resolve_enrich_and_hypothesis_for_write(
+        demo_templates=demo_templates,
+        projects=projects,
+        enrichment=enrichment,
+        hypotheses=hypotheses,
+        current_user_id=current_user_id,
+        enrich_id=enrich_id,
+        gene_expression=gene_expression,
+    )
+    if not resolved:
         raise HTTPException(
             status_code=404, detail="No hypothesis found for this enrichment"
         )
 
-    hypothesis_id = hypothesis["id"]
+    write_ctx = resolved
 
     def run_hypothesis_deployment_blocking():
         return invoke_hypothesis_deployment(
-            current_user_id,
-            hypothesis_id,
-            enrich_id,
+            write_ctx.data_user_id,
+            write_ctx.hypothesis_id,
+            write_ctx.enrich_id,
             go_id,
             wait_timeout=_HYPOTHESIS_FLOW_WAIT_TIMEOUT,
         )
@@ -314,15 +345,29 @@ async def post_hypothesis(
                 status_code=404, detail=body.get("message", "Not found")
             )
         if status_code in (200, 201):
-            refreshed = hypotheses.get_hypotheses(current_user_id, hypothesis_id)
-            return _response_from_hypothesis_document(hypothesis_id, refreshed)
+            refreshed = hypotheses.get_hypotheses(
+                write_ctx.data_user_id, write_ctx.hypothesis_id
+            )
+            return _response_from_hypothesis_document(
+                write_ctx.hypothesis_id,
+                refreshed,
+                enrich_id=write_ctx.enrich_id,
+                project_id=write_ctx.project_id,
+                forked=write_ctx.forked,
+            )
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected hypothesis flow status code: {status_code}",
         )
 
-    refreshed = hypotheses.get_hypotheses(current_user_id, hypothesis_id)
-    return _response_from_hypothesis_document(hypothesis_id, refreshed)
+    refreshed = hypotheses.get_hypotheses(write_ctx.data_user_id, write_ctx.hypothesis_id)
+    return _response_from_hypothesis_document(
+        write_ctx.hypothesis_id,
+        refreshed,
+        enrich_id=write_ctx.enrich_id,
+        project_id=write_ctx.project_id,
+        forked=write_ctx.forked,
+    )
 
 
 @router.delete("/hypothesis")

--- a/src/api/routes/hypothesis.py
+++ b/src/api/routes/hypothesis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
@@ -62,6 +63,27 @@ def _response_from_hypothesis_document(
         response["project_id"] = project_id
     response["forked"] = forked
     return response
+
+
+def _mark_hypothesis_failed(
+    hypotheses: HypothesisHandler, hypothesis_id: str, error: str
+) -> None:
+    """Persist a failed status so the hypothesis never sits ambiguously
+    incomplete forever (e.g. a forked copy with no summary/graph yet)."""
+    try:
+        hypotheses.update_hypothesis(
+            hypothesis_id,
+            {
+                "status": "failed",
+                "error": error,
+                "updated_at": datetime.now(timezone.utc).isoformat(
+                    timespec="milliseconds"
+                )
+                + "Z",
+            },
+        )
+    except Exception:
+        logger.exception(f"Could not mark hypothesis {hypothesis_id} as failed")
 
 
 @router.get("/hypothesis")
@@ -287,6 +309,7 @@ async def post_hypothesis(
         flow_run = await loop.run_in_executor(None, run_hypothesis_deployment_blocking)
     except Exception as e:
         logger.exception("Hypothesis Prefect run_deployment failed")
+        _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, str(e))
         raise HTTPException(
             status_code=503,
             detail=(
@@ -300,6 +323,9 @@ async def post_hypothesis(
 
     state = flow_run.state
     if state is None:
+        _mark_hypothesis_failed(
+            hypotheses, write_ctx.hypothesis_id, "Hypothesis flow run has no state."
+        )
         raise HTTPException(
             status_code=502, detail="Hypothesis flow run has no state; check Prefect."
         )
@@ -314,21 +340,20 @@ async def post_hypothesis(
         )
 
     if state.is_failed() or state.is_crashed() or state.is_cancelled():
-        raise HTTPException(
-            status_code=500,
-            detail=state.message or "Hypothesis flow failed or was cancelled.",
-        )
+        error_detail = state.message or "Hypothesis flow failed or was cancelled."
+        _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, error_detail)
+        raise HTTPException(status_code=500, detail=error_detail)
 
     if not state.is_completed():
-        raise HTTPException(
-            status_code=500,
-            detail=state.message or "Hypothesis flow did not complete successfully.",
-        )
+        error_detail = state.message or "Hypothesis flow did not complete successfully."
+        _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, error_detail)
+        raise HTTPException(status_code=500, detail=error_detail)
 
     try:
         flow_return = state.result(raise_on_failure=True)
     except Exception as e:
         logger.exception("Could not load hypothesis flow result from Prefect state")
+        _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, str(e))
         raise HTTPException(
             status_code=500,
             detail=f"Hypothesis flow finished but result could not be read: {e}",
@@ -341,9 +366,9 @@ async def post_hypothesis(
     ):
         body, status_code = flow_return[0], flow_return[1]
         if status_code == 404:
-            raise HTTPException(
-                status_code=404, detail=body.get("message", "Not found")
-            )
+            error_detail = body.get("message", "Not found")
+            _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, error_detail)
+            raise HTTPException(status_code=404, detail=error_detail)
         if status_code in (200, 201):
             refreshed = hypotheses.get_hypotheses(
                 write_ctx.data_user_id, write_ctx.hypothesis_id
@@ -355,10 +380,9 @@ async def post_hypothesis(
                 project_id=write_ctx.project_id,
                 forked=write_ctx.forked,
             )
-        raise HTTPException(
-            status_code=500,
-            detail=f"Unexpected hypothesis flow status code: {status_code}",
-        )
+        error_detail = f"Unexpected hypothesis flow status code: {status_code}"
+        _mark_hypothesis_failed(hypotheses, write_ctx.hypothesis_id, error_detail)
+        raise HTTPException(status_code=500, detail=error_detail)
 
     refreshed = hypotheses.get_hypotheses(write_ctx.data_user_id, write_ctx.hypothesis_id)
     return _response_from_hypothesis_document(

--- a/src/db/enrichment_handler.py
+++ b/src/db/enrichment_handler.py
@@ -77,6 +77,32 @@ class EnrichmentHandler(BaseHandler):
 
         return enriches if enriches else []
 
+    def ensure_enrich_copy_for_user(self, source_enrich: dict, user_id: str, project_id: str) -> str:
+        """Return an enrichment id owned by user_id for the forked project."""
+        existing = self.get_enrich_by_phenotype_and_variant(
+            source_enrich["phenotype"],
+            source_enrich["variant"],
+            user_id,
+        )
+        if existing and existing.get("project_id") == project_id:
+            return existing["id"]
+
+        new_doc = {key: value for key, value in source_enrich.items() if key != "_id"}
+        new_doc.update(
+            {
+                "id": str(uuid4()),
+                "user_id": user_id,
+                "project_id": project_id,
+                "created_at": datetime.now(timezone.utc),
+            }
+        )
+        self.enrich_collection.insert_one(new_doc)
+        logger.info(
+            f"Copied enrichment {source_enrich['id']} to user {user_id} "
+            f"as {new_doc['id']} in project {project_id}"
+        )
+        return new_doc["id"]
+
     def delete_enrich(self, user_id, enrich_id):
         """Delete enrichment entry"""
         result = self.enrich_collection.delete_one({'id': enrich_id, 'user_id': user_id})

--- a/src/db/gene_expression_handler.py
+++ b/src/db/gene_expression_handler.py
@@ -141,6 +141,26 @@ class GeneExpressionHandler(BaseHandler):
         except Exception as e:
             logger.error(f"Error getting tissue selection: {str(e)}")
             return None
+
+    def ensure_tissue_selection_copy(
+        self,
+        source_user_id: str,
+        source_project_id: str,
+        target_user_id: str,
+        target_project_id: str,
+        variant_id: str,
+    ) -> None:
+        """Copy demo tissue selection to a fork when the fork has none yet."""
+        if self.get_tissue_selection(target_user_id, target_project_id, variant_id):
+            return
+        source = self.get_tissue_selection(source_user_id, source_project_id, variant_id)
+        if source and source.get("tissue_name"):
+            self.save_tissue_selection(
+                target_user_id,
+                target_project_id,
+                variant_id,
+                source["tissue_name"],
+            )
     
     
     def get_ldsc_results_for_project(self, user_id, project_id, limit=10, format='summary'):

--- a/src/db/hypothesis_handler.py
+++ b/src/db/hypothesis_handler.py
@@ -109,6 +109,7 @@ class HypothesisHandler(BaseHandler):
                 "enrich_id": enrich_id,
                 "project_id": project_id,
                 "created_at": datetime.now(timezone.utc),
+                "status": "pending",
             }
         )
         for field in ("summary", "graph", "go_id"):

--- a/src/db/hypothesis_handler.py
+++ b/src/db/hypothesis_handler.py
@@ -1,4 +1,6 @@
 from loguru import logger
+from datetime import datetime, timezone
+from uuid import uuid4
 from .base_handler import BaseHandler
 
 
@@ -71,6 +73,52 @@ class HypothesisHandler(BaseHandler):
             'user_id': user_id,
             'enrich_id': enrich_id
         })
+
+    def ensure_hypothesis_copy_for_user(
+        self,
+        source_hypothesis: dict,
+        user_id: str,
+        enrich_id: str,
+        project_id: str,
+    ) -> str:
+        """Return a hypothesis id owned by user_id for the given enrichment."""
+        variant = (
+            source_hypothesis.get("variant")
+            or source_hypothesis.get("variant_id")
+            or source_hypothesis.get("variant_rsid")
+        )
+        phenotype = source_hypothesis.get("phenotype")
+        if variant and phenotype:
+            existing = self.get_hypothesis_by_phenotype_and_variant_in_project(
+                user_id, project_id, phenotype, variant
+            )
+            if existing:
+                if existing.get("enrich_id") != enrich_id:
+                    self.update_hypothesis(existing["id"], {"enrich_id": enrich_id})
+                return existing["id"]
+
+        existing = self.get_hypothesis_by_enrich(user_id, enrich_id)
+        if existing:
+            return existing["id"]
+
+        new_doc = {key: value for key, value in source_hypothesis.items() if key != "_id"}
+        new_doc.update(
+            {
+                "id": str(uuid4()),
+                "user_id": user_id,
+                "enrich_id": enrich_id,
+                "project_id": project_id,
+                "created_at": datetime.now(timezone.utc),
+            }
+        )
+        for field in ("summary", "graph", "go_id"):
+            new_doc.pop(field, None)
+        self.hypothesis_collection.insert_one(new_doc)
+        logger.info(
+            f"Copied hypothesis {source_hypothesis['id']} to user {user_id} "
+            f"as {new_doc['id']} for enrichment {enrich_id}"
+        )
+        return new_doc["id"]
 
     def get_hypothesis_by_id(self, hypothesis_id):
         """Get hypothesis by ID without user filtering - used by system services"""

--- a/src/db/project_handler.py
+++ b/src/db/project_handler.py
@@ -89,7 +89,9 @@ class ProjectHandler(BaseHandler):
                         errors.append(f"Project {project_id} not found or access denied")
                         continue
 
-                    if project.get("is_template") or project.get("is_demo"):
+                    if project.get("is_template") or (
+                        project.get("is_demo") and not project.get("source_template_id")
+                    ):
                         errors.append(
                             f"Project {project_id} is a demo template and cannot be deleted"
                         )
@@ -105,6 +107,17 @@ class ProjectHandler(BaseHandler):
                     })
                     
                     if result.deleted_count > 0:
+                        if project.get("source_template_id"):
+                            fork_result = self.db["user_demo_forks"].delete_one(
+                                {
+                                    "user_id": user_id,
+                                    "forked_project_id": project_id,
+                                }
+                            )
+                            if fork_result.deleted_count:
+                                logger.info(
+                                    f"Cleared demo fork mapping for project {project_id}"
+                                )
                         deleted_count += 1
                         logger.info(f"Successfully deleted project {project_id} and all associated data")
                     else:
@@ -185,6 +198,14 @@ class ProjectHandler(BaseHandler):
                 'project_id': project_id
             })
             logger.info(f"Deleted {enrich_result.deleted_count} enrichment records for project {project_id}")
+
+            tissue_result = self.db["tissue_selections"].delete_many({
+                "user_id": user_id,
+                "project_id": project_id,
+            })
+            logger.info(
+                f"Deleted {tissue_result.deleted_count} tissue selections for project {project_id}"
+            )
             
             # 6. Delete analysis results
             analysis_result = self.analysis_results_collection.delete_many({
@@ -400,12 +421,14 @@ class ProjectHandler(BaseHandler):
                 "gwas_file_id": gwas_file_id,
                 "name": new_name or f"{source.get('name', 'Project')} (from sample)",
                 "is_template": False,
+                "is_demo": False,
                 "source_template_id": template_project_id,
                 "source_template_slug": template_slug,
                 "created_at": now,
                 "updated_at": now,
             }
         )
+        new_project.pop("demo_slug", None)
         self.projects_collection.insert_one(new_project)
 
         project_query = {"user_id": template_user_id, "project_id": template_project_id}
@@ -420,6 +443,15 @@ class ProjectHandler(BaseHandler):
             project_query,
             target_user_id,
             new_project_id,
+        )
+        self._copy_collection_docs(
+            self.db["tissue_selections"],
+            project_query,
+            target_user_id,
+            new_project_id,
+            transform=lambda doc: doc.update(
+                {"id": str(uuid4()), "created_at": now}
+            ),
         )
 
         run_id_map: dict[str, str] = {}

--- a/src/services/demo/__init__.py
+++ b/src/services/demo/__init__.py
@@ -6,7 +6,9 @@ from src.services.demo.access import (
 from src.services.demo.projects import (
     apply_demo_flags_to_owned_project,
     build_demo_template_summaries,
+    HypothesisWriteContext,
     resolve_fork_project_id,
+    resolve_enrich_and_hypothesis_for_write,
     resolve_hypothesis_data_user_id,
 )
 
@@ -15,6 +17,8 @@ __all__ = [
     "apply_demo_flags_to_owned_project",
     "build_demo_template_summaries",
     "resolve_fork_project_id",
+    "HypothesisWriteContext",
+    "resolve_enrich_and_hypothesis_for_write",
     "resolve_hypothesis_data_user_id",
     "resolve_project_access",
     "resolve_project_access_or_none",

--- a/src/services/demo/projects.py
+++ b/src/services/demo/projects.py
@@ -75,6 +75,11 @@ def resolve_enrich_and_hypothesis_for_write(
         if hypothesis:
             project_id = enrich.get("project_id") or hypothesis.get("project_id")
             if not project_id:
+                logger.warning(
+                    f"[demo] enrich {enrich_id} and hypothesis {hypothesis.get('id')} "
+                    f"for user {current_user_id} both have no project_id; "
+                    "cannot resolve a write context."
+                )
                 return None
             return HypothesisWriteContext(
                 data_user_id=current_user_id,
@@ -92,6 +97,11 @@ def resolve_enrich_and_hypothesis_for_write(
         demo_templates, current_user_id, enrich["project_id"]
     )
     if not access or enrich.get("user_id") != access.owner_user_id:
+        logger.warning(
+            f"[demo] Denied cross-user enrich access: user {current_user_id} "
+            f"requested enrich {enrich_id} (owner={enrich.get('user_id')}, "
+            f"project={enrich.get('project_id')})."
+        )
         return None
 
     source_hypothesis = hypotheses.get_hypothesis_by_enrich(access.owner_user_id, enrich_id)

--- a/src/services/demo/projects.py
+++ b/src/services/demo/projects.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from loguru import logger
 
 from src.db import (
     AnalysisHandler,
     DemoTemplateHandler,
+    EnrichmentHandler,
     FileHandler,
+    GeneExpressionHandler,
     HypothesisHandler,
     ProjectHandler,
 )
@@ -44,6 +47,122 @@ def resolve_hypothesis_data_user_id(
     if not access or hypothesis.get("user_id") != access.owner_user_id:
         return None
     return access.owner_user_id
+
+
+@dataclass(frozen=True)
+class HypothesisWriteContext:
+    data_user_id: str
+    enrich_id: str
+    hypothesis_id: str
+    project_id: str
+    forked: bool
+
+
+def resolve_enrich_and_hypothesis_for_write(
+    *,
+    demo_templates: DemoTemplateHandler,
+    projects: ProjectHandler,
+    enrichment: EnrichmentHandler,
+    hypotheses: HypothesisHandler,
+    current_user_id: str,
+    enrich_id: str,
+    gene_expression: GeneExpressionHandler | None = None,
+) -> HypothesisWriteContext | None:
+    """Resolve writable user/enrich/hypothesis ids for hypothesis generation."""
+    enrich = enrichment.get_enrich(current_user_id, enrich_id)
+    if enrich:
+        hypothesis = hypotheses.get_hypothesis_by_enrich(current_user_id, enrich_id)
+        if hypothesis:
+            project_id = enrich.get("project_id") or hypothesis.get("project_id")
+            if not project_id:
+                return None
+            return HypothesisWriteContext(
+                data_user_id=current_user_id,
+                enrich_id=enrich_id,
+                hypothesis_id=hypothesis["id"],
+                project_id=project_id,
+                forked=False,
+            )
+
+    enrich = enrichment.get_enrich(enrich_id=enrich_id)
+    if not enrich or not enrich.get("project_id"):
+        return None
+
+    access = resolve_project_access_or_none(
+        demo_templates, current_user_id, enrich["project_id"]
+    )
+    if not access or enrich.get("user_id") != access.owner_user_id:
+        return None
+
+    source_hypothesis = hypotheses.get_hypothesis_by_enrich(access.owner_user_id, enrich_id)
+    if not source_hypothesis:
+        return None
+
+    if access.mode == "owner":
+        return HypothesisWriteContext(
+            data_user_id=access.owner_user_id,
+            enrich_id=enrich_id,
+            hypothesis_id=source_hypothesis["id"],
+            project_id=enrich["project_id"],
+            forked=False,
+        )
+
+    project_id, forked = resolve_fork_project_id(
+        demo_templates=demo_templates,
+        projects=projects,
+        current_user_id=current_user_id,
+        project_id=enrich["project_id"],
+        template=access.template,
+    )
+
+    variant = (
+        source_hypothesis.get("variant")
+        or source_hypothesis.get("variant_id")
+        or source_hypothesis.get("variant_rsid")
+        or enrich.get("variant")
+    )
+    phenotype = source_hypothesis.get("phenotype") or enrich.get("phenotype")
+
+    existing_in_fork = None
+    if variant and phenotype:
+        existing_in_fork = hypotheses.get_hypothesis_by_phenotype_and_variant_in_project(
+            current_user_id, project_id, phenotype, variant
+        )
+
+    user_enrich_id = enrichment.ensure_enrich_copy_for_user(
+        enrich, current_user_id, project_id
+    )
+
+    if existing_in_fork:
+        user_hypothesis_id = existing_in_fork["id"]
+        if existing_in_fork.get("enrich_id") != user_enrich_id:
+            hypotheses.update_hypothesis(
+                user_hypothesis_id, {"enrich_id": user_enrich_id}
+            )
+    else:
+        user_hypothesis_id = hypotheses.ensure_hypothesis_copy_for_user(
+            source_hypothesis,
+            current_user_id,
+            user_enrich_id,
+            project_id,
+        )
+
+    if variant and gene_expression:
+        gene_expression.ensure_tissue_selection_copy(
+            access.owner_user_id,
+            enrich["project_id"],
+            current_user_id,
+            project_id,
+            variant,
+        )
+
+    return HypothesisWriteContext(
+        data_user_id=current_user_id,
+        enrich_id=user_enrich_id,
+        hypothesis_id=user_hypothesis_id,
+        project_id=project_id,
+        forked=forked,
+    )
 
 
 def _fork_metadata(


### PR DESCRIPTION
## Summary

Demo template projects are shared, read-only data owned by a single template account. This PR makes it safe for users to actually interact with themL generating hypotheses for different GO terms and deleting their own forks, by forking a private copy per user on write, instead of writing directly against (or being blocked by) the shared template data.

## Problems

1. **Changing the GO term on a demo project did nothing.** `Fixed`
2. **Forked demo projects could not be deleted.** `Fixed`
3. **Tissue selection wasn't carried over to forks.** `Fixed`
4. **Fork deletion cleanup was incomplete.** `Fixed`

## Changes

- Added `resolve_enrich_and_hypothesis_for_write` (`src/services/demo/projects.py`), used by `POST /hypothesis`, which detects when the enrichment being acted on belongs to a demo template rather than the current user, and transparently forks a private copy of the project (or reuses an existing fork) plus the specific enrichment, hypothesis, and tissue selection into the user's own account before running the hypothesis flow.
- `fork_project_from_template` now explicitly sets `is_demo: False` and drops `demo_slug` on the new fork document, and now also copies the `tissue_selections` collection into the fork.
- `bulk_delete_projects`'s guard was hardened to `is_template or (is_demo and not source_template_id)` as a second line of defense, and deletion now also cleans up `tissue_selections` and the `user_demo_forks` mapping.
- `ensure_tissue_selection_copy` copies the specific variant's tissue selection into the fork at hypothesis-write time if it isn't already there.
- Copied hypotheses are stamped `status: "pending"` on creation, and `post_hypothesis` now persists `status: "failed"` + an error message on every flow-failure path — previously a failure left a (possibly newly-forked) hypothesis stuck looking permanently "Running" forever.
- Added a warning log for the previously-silent case where neither `enrich.project_id` nor `hypothesis.project_id` can be resolved.