### PR TITLE
feat(cd): split staging deploy into dev and approved staging jobs

### DIFF
--- a/.github/workflows/cd-staging-deployment.yml
+++ b/.github/workflows/cd-staging-deployment.yml
@@ -5,8 +5,119 @@ on:
     types: [deploy-staging]
 
 jobs:
-  deploy:
-    runs-on: self-hosted
+  deploy-dev:
+    runs-on: [self-hosted, dev-runner]
+    steps:
+      - name: Debug workflow info
+        run: |
+          echo "Event Type: ${{ github.event.action }}"
+          echo "Image Tag: ${{ github.event.client_payload.image_tag }}"
+          echo "Triggered by: ${{ github.actor }}"
+
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_STAGING }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
+
+      - name: Deploy to Kubernetes
+        run: |
+          set -euo pipefail
+
+          NAMESPACE="hypothesis-staging"
+          TAG="${{ github.event.client_payload.image_tag }}"
+
+          if [ -z "$TAG" ]; then
+            TAG="staging"
+          fi
+
+          echo "Using image tag: $TAG"
+
+          kubectl set image deployment/hypothesis-api \
+            api=rejuvebio/hypothesis-generation-api-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prolog-service \
+            prolog=rejuvebio/hypothesis-generation-prolog-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prefect-service \
+            prefect-service=rejuvebio/hypothesis-generation-prefect-service:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/prefect-deployment \
+            prefect-deployment=rejuvebio/hypothesis-generation-prefect-deployment:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/dask-scheduler \
+            dask-scheduler=rejuvebio/hypothesis-generation-dask-scheduler:${TAG} \
+            -n "$NAMESPACE"
+
+          kubectl set image deployment/dask-worker \
+            dask-worker=rejuvebio/hypothesis-generation-dask-worker:${TAG} \
+            -n "$NAMESPACE"
+
+      - name: Wait for rollout
+        run: |
+          set -euo pipefail
+          kubectl rollout status deployment/hypothesis-api -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prolog-service -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prefect-service -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/prefect-deployment -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/dask-scheduler -n hypothesis-staging --timeout=180s
+          kubectl rollout status deployment/dask-worker -n hypothesis-staging --timeout=180s
+
+      - name: Verify all pods
+        run: |
+          kubectl get pods -n hypothesis-staging
+
+      - name: Send success email
+        if: success()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline SUCCESS - Hypothesis Generation Deployed to Dev"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            Deployment to the dev server completed successfully!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+
+            All pods updated and running in staging namespace.
+            Approve the deploy-staging job in this run to promote.
+
+      - name: Send failure email
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline FAILED - Hypothesis Generation Dev Deploy"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            Dev deployment failed!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+
+            Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  deploy-staging:
+    needs: deploy-dev
+    environment: production
+    runs-on: [self-hosted, prod-runner]
     steps:
       - name: Debug workflow info
         run: |


### PR DESCRIPTION
Splits the single deploy job in cd-staging-deployment.yml into:
- deploy-dev: runs on dev-runner, no gate
- deploy-staging: needs deploy-dev, gated behind the `production`
  environment (manual approval), runs on prod-runner

Same target namespace/deployments as before — only where and in what
order changes